### PR TITLE
Adding curl timeouts for Solr searches

### DIFF
--- a/modules/pantheon/pantheon_apachesolr/Pantheon_Apache_Solr_Service.php
+++ b/modules/pantheon/pantheon_apachesolr/Pantheon_Apache_Solr_Service.php
@@ -442,13 +442,10 @@ class PantheonApacheSolrService {
     curl_setopt($ch, CURLOPT_SSLCERT, $client_cert);
 
     // set URL and other appropriate options
-    $opts = array(
-      CURLOPT_URL => $url,
-      CURLOPT_HEADER => 1,
-      CURLOPT_PORT => $port,
-      CURLOPT_RETURNTRANSFER => 1,
-      CURLOPT_HTTPHEADER => array('Content-type:text/xml;', 'Expect:'),
-    );
+    $opts = pantheon_apachesolr_curlopts();
+    $opts[CURLOPT_URL] = $url;
+    $opts[CURLOPT_PORT] = $port;
+
     curl_setopt_array($ch, $opts);
 
     // If we are doing a delete request...

--- a/modules/pantheon/pantheon_apachesolr/Pantheon_Search_Api_Solr_Service.php
+++ b/modules/pantheon/pantheon_apachesolr/Pantheon_Search_Api_Solr_Service.php
@@ -96,13 +96,10 @@ class PanteheonSearchApiSolrHttpTransport extends Apache_Solr_HttpTransport_Abst
     $ch = curl_init();
     curl_setopt($ch, CURLOPT_SSLCERT, $client_cert);
 
-    $opts = array(
-      CURLOPT_URL => $url,
-      CURLOPT_HEADER => 1,
-      CURLOPT_PORT => $port,
-      CURLOPT_RETURNTRANSFER => 1,
-      CURLOPT_HTTPHEADER => array('Content-type:text/xml;', 'Expect:'),
-    );
+    $opts = pantheon_apachesolr_curlopts();
+    $opts[CURLOPT_URL] = $url;
+    $opts[CURLOPT_PORT] = $port;
+
     if ($timeout) {
       $opts[CURLOPT_CONNECTTIMEOUT] = $timeout;
     }

--- a/modules/pantheon/pantheon_apachesolr/pantheon_apachesolr.module
+++ b/modules/pantheon/pantheon_apachesolr/pantheon_apachesolr.module
@@ -19,6 +19,16 @@ function pantheon_apachesolr_menu() {
   return $items;
 }
 
+function pantheon_apachesolr_curlopts() {
+  return array(
+    CURLOPT_HEADER => 1,
+    CURLOPT_RETURNTRANSFER => 1,
+    CURLOPT_TIMEOUT_MS => 5000,
+    CURLOPT_CONNECTTIMEOUT_MS => 5000,
+    CURLOPT_HTTPHEADER => array('Content-type:text/xml;', 'Expect:'),
+  );
+}
+
 function pantheon_apachesolr_update_schema($schema) {
   $ch = curl_init();
   $host = 'index.'. variable_get('pantheon_tier', 'live') .'.getpantheon.com';


### PR DESCRIPTION
This pull factors out some of the CURLOPTS used to connect to Solr and adds connection and request timeouts.  The timeouts are a short-circuit designed to terminate longer-than-normal Solr requests without propagating latency issues to the rest of the site.

We're using 5 second timeouts as a conservative estimate, as most Solr requests should take a few hundred milliseconds round-trip.
