### PR TITLE
Updating permissions for Pantheon Apachesolr module

### DIFF
--- a/modules/pantheon/pantheon_apachesolr/pantheon_apachesolr.module
+++ b/modules/pantheon/pantheon_apachesolr/pantheon_apachesolr.module
@@ -13,7 +13,7 @@ function pantheon_apachesolr_menu() {
     'description'        => 'Configure Pantheon\'s Apache Solr, including selecting your schema.xml.',
     'page callback'      => 'drupal_get_form',
     'page arguments'     => array('pantheon_apachesolr_settings'),
-    'access arguments'   => array('administer search'),
+    'access arguments'   => array('access administration pages'),
     'weight'             => -8,
   );
   return $items;


### PR DESCRIPTION
This switches the Pantheon Apachesolr module to use the 'access administration pages' permission instead of 'administer search' since search.module is not a dependency (and shouldn't be). 
