### PR TITLE
Override search_api server configuration form to make it clear that Pant...

### DIFF
--- a/modules/pantheon/pantheon_apachesolr/Pantheon_Search_Api_Solr_Service.php
+++ b/modules/pantheon/pantheon_apachesolr/Pantheon_Search_Api_Solr_Service.php
@@ -102,6 +102,20 @@ class PantheonApachesolrSearchApiSolrService extends SearchApiSolrService {
 
   protected $connection_class = 'PantheonApachesolrSearchApiSolrConnection';
 
+  /**
+   * Overrides SearchApiSolrService::configurationForm().
+   *
+   * Hides unnecessary settings from Search API server settings form.
+   */
+  public function configurationForm(array $form, array &$form_state) {
+    $form['note'] = array(
+      '#type' => 'item',
+      '#title' => t('Pantheon Notice'),
+      '#markup' => '<p>'. t('You should not need to configure solr host connections: Pantheon is managing your Solr connection settings.') .'</p>',
+    );
+
+    return $form;
+  }
 }
 
 /**


### PR DESCRIPTION
...heon is managing the Solr connection settings, and that the regular search_api server settings are not used.

Currently deployed on Pantheon using search_api 7.x-1.7 and search_api_solr 7.x-1.1
