### PR TITLE
Updating Help Text for Pantheon Apache Solr Module 

### DIFF
--- a/modules/pantheon/pantheon_apachesolr/pantheon_apachesolr.module
+++ b/modules/pantheon/pantheon_apachesolr/pantheon_apachesolr.module
@@ -637,8 +637,9 @@ function pantheon_apachesolr_requirements($phase) {
     if ($pantheon_apachesolr_schema == '') {
       $requirements['pantheon_apachesolr']['severity'] = REQUIREMENT_ERROR;
       $requirements['pantheon_apachesolr']['value'] = t('Schema not posted!');
-      $requirements['pantheon_apachesolr']['description'] = t('You have not posted the schema.xml to the @pantheon_environment environment using the <a href="@url">post schema</a> interface.', array(
+      $requirements['pantheon_apachesolr']['description'] = t('You have not posted the schema.xml to the @pantheon_environment environment. Make sure you have <a href="@enableurl" target="_blank">enabled the Pantheon Apache Solr add on</a> and then <a href="@url">post your schema</a> using the module interface. ', array(
         '@url' => url('admin/config/search/pantheon/schema'),
+        '@enableurl' => 'https://www.getpantheon.com/docs/articles/sites/apache-solr/',
         '@pantheon_environment' => variable_get('pantheon_environment', 'dev'),
       ));
     }

--- a/modules/pantheon/pantheon_apachesolr/pantheon_apachesolr.module
+++ b/modules/pantheon/pantheon_apachesolr/pantheon_apachesolr.module
@@ -23,7 +23,7 @@ function pantheon_apachesolr_help($path, $arg) {
       $output .= '<ol>';
       $output .= '<li>' . t('For each Pantheon environment (dev, test and live), post the desired schema.xml to the Apache Solr server using the <a href="@url">post schema</a> interface. Step-by-step instructions can be found in <a href="@desk">Apache Solr on Pantheon</a>.', array(
         '@url' => url('admin/config/search/pantheon/schema'),
-        '@desk' => url('http://helpdesk.getpantheon.com/customer/portal/articles/361249'),
+        '@desk' => url('https://www.getpantheon.com/docs/articles/sites/apache-solr/'),
       )) . '</p>';
       $output .= '</ol>';
 


### PR DESCRIPTION
Here is a small pull request to update the help text of the Pantheon Apache Solr module to alert users that they need to enable the Add On first as per https://www.getpantheon.com/docs/articles/sites/apache-solr/.