### PR TITLE
Also include private paths in image flush

### DIFF
--- a/modules/pantheon/pantheon_api/pantheon_api.module
+++ b/modules/pantheon/pantheon_api/pantheon_api.module
@@ -37,7 +37,9 @@ function pantheon_api_image_path_flush($path) {
     $image_path = image_style_path($style['name'], $path);
     if (strpos($image_path, 'public://') === 0) {
       $paths[] = str_replace('public://', '/', $image_path);
-    }
+    } elseif (strpos($image_path, 'private://') === 0) {
+      $paths[] = str_replace('private://', '/', $image_path);
+    }    
   }
   if (count($paths) > 0) {
     pantheon_bulk_file_delete($paths);


### PR DESCRIPTION
This is in response to an internal customer ticket in which it was reported that private images were not being flushed as expected. This was a result of our only including strings beginning with ```public://``` in our paths array. This fix adds ```private://```. While an ```elseif``` condition is rather inelegant it was chosen because (a) following the established pattern is safer than new patterns and (b) two ```strpos``` perform better than one ```preg_match```. 

@joshkoenig ^^ Do you agree with this? 

 