### PR TITLE
Fix a call to pantheon_bulk_file_delete() without a check first.

### DIFF
--- a/modules/pantheon/pantheon_api/pantheon_api.module
+++ b/modules/pantheon/pantheon_api/pantheon_api.module
@@ -39,7 +39,7 @@ function pantheon_api_image_path_flush($path) {
       $paths[] = str_replace('public://', '/', $image_path);
     }
   }
-  if (count($paths) > 0) {
+  if (count($paths) > 0 && function_exists('pantheon_bulk_file_delete')) {
     pantheon_bulk_file_delete($paths);
   }
 }


### PR DESCRIPTION
Follow-up to #37, #38, as originally reported by @phenaproxima in #drupal-contribute