### PR TITLE
Fix false positives for schema posting and kalabox support

### DIFF
--- a/modules/pantheon/pantheon_apachesolr/pantheon_apachesolr.module
+++ b/modules/pantheon/pantheon_apachesolr/pantheon_apachesolr.module
@@ -191,8 +191,16 @@ function pantheon_apachesolr_post_schema_exec($schema) {
   );
   curl_setopt_array($ch, $opts);
   $response = curl_exec($ch);
+  $info = curl_getinfo($ch);
+  $success_codes = array(
+    '200',
+    '201',
+    '202',
+    '204'
+  );
+  $success = (in_array($info['http_code'], $success_codes));
   fclose($file);
-  if ($response == NULL) {
+  if (!$success) {
     watchdog('pantheon_apachesolr', 'Error !error posting !schema to !url', array(
       '!error' => curl_error($ch),
       '!schema' => $schema,
@@ -203,7 +211,7 @@ function pantheon_apachesolr_post_schema_exec($schema) {
     variable_set('pantheon_apachesolr_schema', $schema);
   }
 
-  return $response;
+  return $success;
 }
 
 /**
@@ -306,7 +314,6 @@ function pantheon_apachesolr_query_submit($form, &$form_state) {
   $host = PANTHEON_APACHESOLR_HOST;
   $path = 'sites/self/environments/'. variable_get('pantheon_environment', 'dev') .'/index';
   $url = 'https://'. $host .'/'. $path . $form_state['values']['query'];
-
 
   $ch = curl_init();
   curl_setopt_array($ch, pantheon_apachesolr_curlopts());


### PR DESCRIPTION
This provides out-of-the-box support for the pantheon_apachesolr module when using the upcoming Pantheon Environment on Kalabox 2. It also reduces false positives when posting the schema ie it currently reports the schema has been posted with success even with a 403 and non null response aka failing