### PR TITLE
Removed requirement to return response in XML format becase we expect response in JSON

### DIFF
--- a/modules/pantheon/pantheon_apachesolr/pantheon_apachesolr.module
+++ b/modules/pantheon/pantheon_apachesolr/pantheon_apachesolr.module
@@ -141,7 +141,6 @@ function pantheon_apachesolr_curlopts() {
     CURLOPT_RETURNTRANSFER => 1,
     CURLOPT_TIMEOUT_MS => 5000,
     CURLOPT_CONNECTTIMEOUT_MS => 5000,
-    CURLOPT_HTTPHEADER => array('Content-type:text/xml;', 'Expect:'),
   );
 }
 


### PR DESCRIPTION
As result any long queries that are sent using POST (longer than 4000 bytes) failed because it can't parse response in unexpected XML format