### PR TITLE
Prevent creation of .htaccess when running drush

### DIFF
--- a/includes/file.inc
+++ b/includes/file.inc
@@ -477,7 +477,7 @@ function file_ensure_htaccess() {
  *   already present. Defaults to FALSE.
  */
 function file_create_htaccess($directory, $private = TRUE, $force_overwrite = FALSE) {
-  if (isset($_ENV('PANTHEON_ENVIRONMENT')) {
+  if (isset($_ENV['PANTHEON_ENVIRONMENT'])) {
     // Skip on Pantheon since we use nginx and this can hang.
     return;
   }

--- a/includes/file.inc
+++ b/includes/file.inc
@@ -477,7 +477,7 @@ function file_ensure_htaccess() {
  *   already present. Defaults to FALSE.
  */
 function file_create_htaccess($directory, $private = TRUE, $force_overwrite = FALSE) {
-  if (isset($_SERVER['PANTHEON_ENVIRONMENT'])) {
+  if (defined('PANTHEON_ENVIRONMENT')) {
     // Skip on Pantheon since we use nginx and this can hang.
     return;
   }

--- a/includes/file.inc
+++ b/includes/file.inc
@@ -477,7 +477,7 @@ function file_ensure_htaccess() {
  *   already present. Defaults to FALSE.
  */
 function file_create_htaccess($directory, $private = TRUE, $force_overwrite = FALSE) {
-  if (defined('PANTHEON_ENVIRONMENT')) {
+  if (isset($_ENV('PANTHEON_ENVIRONMENT')) {
     // Skip on Pantheon since we use nginx and this can hang.
     return;
   }


### PR DESCRIPTION
A client that has lots and lots of Pantheon sites runs a number of mass operations on all their sites via drush. They are experiencing intermittent failures where Drupal is trying to write the `'private://.htaccess'` file, getting this error:

```
File
/srv/bindings/xxxxxxxxxxxxxxxxxxxxxxxx/code/includes/file.inc,
line 500
file_put_contents(private:///.htaccess): failed to open stream:          [error]
"DrupalPrivateStreamWrapper::stream_open" call failed
```

However, in includes/file.inc, there's code to prevent this from happening on Pantheon:

```
function file_create_htaccess($directory, $private = TRUE, $force_overwrite = FALSE) {
  if (isset($_SERVER['PANTHEON_ENVIRONMENT'])) {
    // Skip on Pantheon since we use nginx and this can hang.
    return;
  }
  // ...
}
```

... except, it's using `$_SERVER` which won't always be setup correctly for drush per these docs:

https://pantheon.io/docs/read-environment-config/#using-%24_server

Patching this to `defined('PANTHEON_ENVIRONMENT')` fixes the problem in my testing!