### PR TITLE
Updated db.check.php healthcheck to be PHP7-compatible.

### DIFF
--- a/misc/healthchecks/db.check.php
+++ b/misc/healthchecks/db.check.php
@@ -3,12 +3,12 @@
 if (isset($_SERVER['PRESSFLOW_SETTINGS'])) {
   $pressflow_config = json_decode($_SERVER['PRESSFLOW_SETTINGS'], TRUE);
   $db = $pressflow_config['databases']['default']['default'];
-  $link = mysql_connect($db['host'] . ':' . $db['port'], $db['username'], $db['password']);
+  $link = mysqli_connect($db['host'] . ':' . $db['port'], $db['username'], $db['password']);
   if (!$link) {
-      fail('Could not connect: ' . mysql_error());
+      fail('Could not connect: ' . mysqli_error());
   }
   echo "OK\n";
-  mysql_close($link);
+  mysqli_close($link);
 }
 else {
   fail("No config found.\n");


### PR DESCRIPTION
I'm not sure if the health checks found in `misc/healthchecks` are actively used but we recently ran some static code analysis tools against our custom D7 upstream repo codebase (that is based on drops-7) to check for PHP7 compatibility issues in response to the #123.  The `db-check.php` file generated some warnings because it uses the `mysql_connect()`, `mysql_error()`, `mysql_close()` PHP functions which were removed as of PHP 7.0 (see http://php.net/manual/en/function.mysql-connect.php).
