### PR TITLE
Update to PHP 7.2 by default

### DIFF
--- a/pantheon.upstream.yml
+++ b/pantheon.upstream.yml
@@ -3,4 +3,4 @@
 # Override the defaults specified here in a site-specific `pantheon.yml` file.
 # For more information see: https://pantheon.io/docs/pantheon-upstream-yml
 api_version: 1
-php_version: 7.1
+php_version: 7.2


### PR DESCRIPTION
See discussion at pantheon-systems/drops-6#26.

In the case of drops-7, PHP 7.2 has been supported since Drupal 7.61.