### PR TITLE
Drops 7.63

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,7 @@
+Drupal 7.63, 2019-01-16
+-----------------------
+- Fixed a fatal error for some Drush users introduced by SA-CORE-2019-002.
+
 Drupal 7.62, 2019-01-15
 -----------------------
 - Fixed security issues:

--- a/includes/bootstrap.inc
+++ b/includes/bootstrap.inc
@@ -8,7 +8,7 @@
 /**
  * The current system version.
  */
-define('VERSION', '7.62');
+define('VERSION', '7.63');
 
 /**
  * Core API compatibility.


### PR DESCRIPTION
This is a hotfix/bugfix update. 

See https://www.drupal.org/project/drupal/releases/7.63 for more information.

Please note that I cannot merge automatically: someone else please review and merge.

Generated with:
```
$ git clone --recursive $my_fork_clone_url
$ git checkout -t origin/master
$ git remote add upstream https://github.com/pantheon-systems/drops-7.git
$ git remote add drupal https://git.drupal.org/project/drupal.git
$ git fetch --all -t -p
$ git checkout -b drops-7.63
$ git merge 7.63
```

There were merge conflicts when I tried to merge 7.63 which might explain @pantheon-ci-bot's tardiness. I resolved the merge conflicts to look like https://github.com/pressflow/7/commit/593ea87b183871646c0444e8267762f38d2e5d4f , which is a unification of the following commits to Drupal core:

- https://cgit.drupalcode.org/drupal/commit/?id=b34c8b9a532e272d9d2d05ddc470d80d1500e480
- https://cgit.drupalcode.org/drupal/commit/?id=021b0fd5d6ac752c472655b16c68286acba8afd0
- https://cgit.drupalcode.org/drupal/commit/?id=a56132631b05be6f893a14efd37f69e10b02ae0b

Once I'd resolved them, I finished the merged and pushed my branch with:
```
$ git commit
$ git push --set-upstream origin drops-7.63
```

... at which point the Github UI gave me the option to create this pull request for my drops-7.63 branch at https://github.com/pantheon-systems/drops-7 

I had to change the base branch from `default` to `master` after creating the PR; it now shows the right diff; but still seems to want to include commits from 2017 in Github's conversation and commits views.