### PR TITLE
[CORE-1354] Enforce HTTPS by default.

### DIFF
--- a/pantheon.upstream.yml
+++ b/pantheon.upstream.yml
@@ -4,3 +4,6 @@
 # For more information see: https://pantheon.io/docs/pantheon-upstream-yml
 api_version: 1
 php_version: 7.2
+
+# See https://pantheon.io/docs/pantheon-yml/#enforce-https--hsts for valid values.
+enforce_https: transitional


### PR DESCRIPTION
Enforce HTTPS by default. For more info see https://pantheon.io/blog/pantheon-now-enforces-https-default-plus-really-simple-hsts