### PR TITLE
Update to Drupal 7.72. For more information, see https://www.drupal.org/project/drupal/releases/7.72

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,8 @@
+Drupal 7.72, 2020-06-17
+-----------------------
+- Fixed security issues:
+   - SA-CORE-2020-004
+
 Drupal 7.71, 2020-06-03
 -----------------------
 - Fix for jQuery Form bug in Chromium-based browsers

--- a/includes/bootstrap.inc
+++ b/includes/bootstrap.inc
@@ -8,7 +8,7 @@
 /**
  * The current system version.
  */
-define('VERSION', '7.71');
+define('VERSION', '7.72');
 
 /**
  * Core API compatibility.

--- a/includes/form.inc
+++ b/includes/form.inc
@@ -1135,12 +1135,8 @@ function drupal_prepare_form($form_id, &$form, &$form_state) {
  * Helper function to call form_set_error() if there is a token error.
  */
 function _drupal_invalid_token_set_form_error() {
-  $path = current_path();
-  $query = drupal_get_query_parameters();
-  $url = url($path, array('query' => $query));
-
   // Setting this error will cause the form to fail validation.
-  form_set_error('form_token', t('The form has become outdated. Copy any unsaved work in the form below and then <a href="@link">reload this page</a>.', array('@link' => $url)));
+  form_set_error('form_token', t('The form has become outdated. Press the back button, copy any unsaved work in the form, and then reload the page.'));
 }
 
 /**
@@ -1181,6 +1177,11 @@ function drupal_validate_form($form_id, &$form, &$form_state) {
   if (!empty($form['#token'])) {
     if (!drupal_valid_token($form_state['values']['form_token'], $form['#token']) || !empty($form_state['invalid_token'])) {
       _drupal_invalid_token_set_form_error();
+      // Ignore all submitted values.
+      $form_state['input'] = array();
+      $_POST = array();
+      // Make sure file uploads do not get processed.
+      $_FILES = array();
       // Stop here and don't run any further validation handlers, because they
       // could invoke non-safe operations which opens the door for CSRF
       // vulnerabilities.
@@ -1848,6 +1849,9 @@ function form_builder($form_id, &$element, &$form_state) {
           _drupal_invalid_token_set_form_error();
           // This value is checked in _form_builder_handle_input_element().
           $form_state['invalid_token'] = TRUE;
+          // Ignore all submitted values.
+          $form_state['input'] = array();
+          $_POST = array();
           // Make sure file uploads do not get processed.
           $_FILES = array();
         }

--- a/modules/file/tests/file.test
+++ b/modules/file/tests/file.test
@@ -409,7 +409,7 @@ class FileManagedFileElementTestCase extends FileFieldTestCase {
           'form_token' => 'invalid token',
         );
         $this->drupalPost($path, $edit, t('Save'));
-        $this->assertText('The form has become outdated. Copy any unsaved work in the form below');
+        $this->assertText('The form has become outdated.');
         $last_fid = $this->getLastFileId();
         $this->assertEqual($last_fid_prior, $last_fid, 'File was not saved when uploaded with an invalid form token.');
 

--- a/modules/simpletest/tests/form.test
+++ b/modules/simpletest/tests/form.test
@@ -521,6 +521,9 @@ class FormsTestCase extends DrupalWebTestCase {
     $form_state['values'] = array();
     drupal_prepare_form($form_id, $form, $form_state);
 
+    // Set the CSRF token in the user-provided input.
+    $form_state['input']['form_token'] = $form['form_token']['#default_value'];
+
     // This is the main function we want to test: it is responsible for
     // populating user supplied $form_state['input'] to sanitized
     // $form_state['values'].
@@ -687,7 +690,7 @@ class FormValidationTestCase extends DrupalWebTestCase {
     $this->drupalPost(NULL, $edit, 'Save');
     $this->assertNoFieldByName('name', '#value changed by #validate', 'Form element #value was not altered.');
     $this->assertNoText('Name value: value changed by form_set_value() in #validate', 'Form element value in $form_state was not altered.');
-    $this->assertText('The form has become outdated. Copy any unsaved work in the form below');
+    $this->assertText('The form has become outdated.');
   }
 
   /**


### PR DESCRIPTION
Update from Drupal 7.71 to Drupal 7.72.

Before merging this PR, check the [build results on CircleCI](https://circleci.com/gh/pantheon-systems/drops-7), and then visit the test site and confirm that the correct version of Drupal was, in fact, installed and tested.

Optionally, you may also create your own test site:

  - Create a new Drupal 7 site on Pantheon.
  - When site creation is finished, visit dashboard.
  - Switch to "git" mode.
  - Clone your site locally.
  - Apply the files from this PR on top of your local checkout.
    - git remote add drops-7 git@github.com:pantheon-systems/drops-7.git
    - git fetch drops-7
    - git merge drops-7/update-7.72
  - Push your files back up to Pantheon.
  - Switch back to sftp mode.
  - Visit your site and step through the installation process.
