### PR TITLE
[CMS-147] + [PRT-227] Update to PHP 7.4 and MariaDB 10.4

### DIFF
--- a/pantheon.upstream.yml
+++ b/pantheon.upstream.yml
@@ -3,8 +3,12 @@
 # Override the defaults specified here in a site-specific `pantheon.yml` file.
 # For more information see: https://pantheon.io/docs/pantheon-upstream-yml
 api_version: 1
-php_version: 7.2
+php_version: 7.4
 drush_version: 8
+
+# See https://pantheon.io/docs/pantheon-yml#specify-a-version-of-mariadb
+database:
+  version: 10.4
 
 # See https://pantheon.io/docs/pantheon-yml/#enforce-https--hsts for valid values.
 enforce_https: transitional


### PR DESCRIPTION
For details, see https://pantheon.io/docs/pantheon-yml#specify-a-version-of-mariadb

See also pantheon-systems/documentation#6928, which modifies that section.