### PR TITLE
Update to Drupal 7.86. For more information, see https://www.drupal.org/project/drupal/releases/7.86

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,9 @@
+Drupal 7.86, 2022-01-18
+-----------------------
+- Fixed security issues:
+   - SA-CORE-2022-001
+   - SA-CORE-2022-002
+
 Drupal 7.85, 2022-01-12
 -----------------------
 - Fix session cookies for sites with different base_urls but a shared domain

--- a/includes/bootstrap.inc
+++ b/includes/bootstrap.inc
@@ -8,7 +8,7 @@
 /**
  * The current system version.
  */
-define('VERSION', '7.85');
+define('VERSION', '7.86');
 
 /**
  * Core API compatibility.

--- a/misc/ui/jquery.ui.datepicker-1.13.0-backport.js
+++ b/misc/ui/jquery.ui.datepicker-1.13.0-backport.js
@@ -1,0 +1,36 @@
+/**
+ * Backport of security fixes from:
+ * https://github.com/jquery/jquery-ui/pull/1953
+ * https://github.com/jquery/jquery-ui/pull/1954
+ */
+
+(function ($, Drupal) {
+
+  // No backport is needed if we're already on jQuery UI 1.13 or higher.
+  var versionParts = $.ui.datepicker.version.split('.');
+  var majorVersion = parseInt(versionParts[0]);
+  var minorVersion = parseInt(versionParts[1]);
+  if ( (majorVersion > 1) || (majorVersion === 1 && minorVersion >= 13) ) {
+    return;
+  }
+
+  var fnOriginalGet = $.datepicker._get;
+  $.extend($.datepicker, {
+
+    _get: function( inst, name ) {
+      var val = fnOriginalGet.call(this, inst, name);
+
+      // @see https://github.com/jquery/jquery-ui/pull/1954
+      if (name === 'altField') {
+        val = $(document).find(val);
+      }
+      // @see https://github.com/jquery/jquery-ui/pull/1953
+      else if ($.inArray(name, ['appendText', 'buttonText', 'prevText', 'currentText', 'nextText', 'closeText']) !== -1) {
+        val = Drupal.checkPlain(val);
+      }
+
+      return val;
+    }
+
+  })
+})(jQuery, Drupal);

--- a/misc/ui/jquery.ui.dialog-1.13.0-backport.js
+++ b/misc/ui/jquery.ui.dialog-1.13.0-backport.js
@@ -1,0 +1,58 @@
+/**
+ * Backport of security fixes from:
+ * https://bugs.jqueryui.com/ticket/6016
+ * https://github.com/jquery/jquery-ui/pull/1635/files
+ */
+
+(function ($) {
+
+  // Parts of this backport differ by jQuery version.
+  var versionParts = $.ui.dialog.version.split('.');
+  var majorVersion = parseInt(versionParts[0]);
+  var minorVersion = parseInt(versionParts[1]);
+
+  if (majorVersion === 1 && minorVersion < 13) {
+    var _originalSetOption = $.ui.dialog.prototype._setOption;
+    var _originalCreateTitlebar = $.ui.dialog.prototype._createTitlebar;
+
+    $.extend($.ui.dialog.prototype, {
+
+      _createTitlebar: function () {
+        if (this.options.closeText) {
+          this.options.closeText = Drupal.checkPlain(this.options.closeText);
+        }
+        _originalCreateTitlebar.apply(this, arguments);
+      },
+
+      _setOption: function (key, value) {
+        if (key === 'title' || key == 'closeText') {
+          if (value) {
+            value = Drupal.checkPlain(value);
+          }
+        }
+        _originalSetOption.apply(this, [key, value]);
+      }
+    });
+
+    if (majorVersion === 1 && minorVersion < 10) {
+      var _originalCreate = $.ui.dialog.prototype._create;
+
+      $.extend($.ui.dialog.prototype, {
+
+        _create: function () {
+          if (!this.options.title) {
+            var defaultTitle = this.element.attr('title');
+            // .attr() might return a DOMElement
+            if (typeof defaultTitle !== "string") {
+              defaultTitle = "";
+            }
+            this.options.title = defaultTitle;
+          }
+          this.options.title = Drupal.checkPlain(this.options.title);
+          _originalCreate.apply(this, arguments);
+        },
+      });
+    }
+  }
+
+})(jQuery);

--- a/misc/ui/jquery.ui.position-1.13.0-backport.js
+++ b/misc/ui/jquery.ui.position-1.13.0-backport.js
@@ -1,0 +1,30 @@
+/**
+ * Backport of security fix from:
+ * https://github.com/jquery/jquery-ui/pull/1955/files
+ */
+
+(function ($) {
+
+  // No backport is needed if we're already on jQuery UI 1.13 or higher.
+  var versionParts = $.ui.version.split('.');
+  var majorVersion = parseInt(versionParts[0]);
+  var minorVersion = parseInt(versionParts[1]);
+  if ( (majorVersion > 1) || (majorVersion === 1 && minorVersion >= 13) ) {
+    return;
+  }
+
+  var fnOriginalPosition = $.fn.position;
+  $.fn.extend({
+    'position': function (options) {
+
+      // Make sure string options are treated as CSS selectors
+      var target = typeof options.of === "string" ?
+        $(document).find(options.of) :
+        $(options.of);
+
+      options.of = (target[0] === undefined) ? null : target;
+      return fnOriginalPosition.call(this, options);
+    }
+  });
+
+})(jQuery);

--- a/modules/system/system.module
+++ b/modules/system/system.module
@@ -1328,6 +1328,7 @@ function system_library() {
     'version' => '1.8.7',
     'js' => array(
       'misc/ui/jquery.ui.datepicker.min.js' => array(),
+      'misc/ui/jquery.ui.datepicker-1.13.0-backport.js' => array(),
     ),
     'css' => array(
       'misc/ui/jquery.ui.datepicker.css' => array(),
@@ -1341,7 +1342,8 @@ function system_library() {
     'website' => 'http://jqueryui.com/demos/dialog/',
     'version' => '1.8.7',
     'js' => array(
-      'misc/ui/jquery.ui.dialog.min.js' => array(),
+      'misc/ui/jquery.ui.dialog.min.js' =>  array(),
+      'misc/ui/jquery.ui.dialog-1.13.0-backport.js' => array(),
     ),
     'css' => array(
       'misc/ui/jquery.ui.dialog.css' => array(),
@@ -1397,6 +1399,7 @@ function system_library() {
     'version' => '1.8.7',
     'js' => array(
       'misc/ui/jquery.ui.position.min.js' => array(),
+      'misc/ui/jquery.ui.position-1.13.0-backport.js' => array(),
     ),
   );
   $libraries['ui.progressbar'] = array(


### PR DESCRIPTION
Update from Drupal 7.85 to Drupal 7.86.

Before merging this PR, check the [build results on CircleCI](https://circleci.com/gh/pantheon-systems/drops-7), and then visit the test site and confirm that the correct version of Drupal was, in fact, installed and tested.

Optionally, you may also create your own test site:

  - Create a new Drupal 7 site on Pantheon.
  - When site creation is finished, visit dashboard.
  - Switch to "git" mode.
  - Clone your site locally.
  - Apply the files from this PR on top of your local checkout.
    - git remote add drops-7 git@github.com:pantheon-systems/drops-7.git
    - git fetch drops-7
    - git merge drops-7/update-7.86
  - Push your files back up to Pantheon.
  - Switch back to sftp mode.
  - Visit your site and step through the installation process.
