### PR TITLE
Update to Drupal 7.94. For more information, see https://www.drupal.org/project/drupal/releases/7.94

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,7 @@
+Drupal 7.94, 2022-12-14
+-----------------------
+- Hotfix for book.module and Select query properties
+
 Drupal 7.93, 2022-12-07
 -----------------------
 - Improved support for PHP 8.2

--- a/includes/bootstrap.inc
+++ b/includes/bootstrap.inc
@@ -8,7 +8,7 @@
 /**
  * The current system version.
  */
-define('VERSION', '7.93');
+define('VERSION', '7.94');
 
 /**
  * Core API compatibility.

--- a/includes/database/select.inc
+++ b/includes/database/select.inc
@@ -949,14 +949,14 @@ class SelectQuery extends Query implements SelectQueryInterface {
    *
    * @var array
    */
-  protected $alterMetaData;
+  public $alterMetaData;
 
   /**
    * The query tags.
    *
    * @var array
    */
-  protected $alterTags;
+  public $alterTags;
 
   /**
    * An array whose elements specify a query to UNION, and the UNION type. The

--- a/modules/book/book.module
+++ b/modules/book/book.module
@@ -872,15 +872,12 @@ function book_menu_name($bid) {
  * Implements hook_node_load().
  */
 function book_node_load($nodes, $types) {
-  $allowed = variable_get('book_allowed_types', array('book'));
-  if (array_intersect($types, $allowed)) {
-    $result = db_query("SELECT * FROM {book} b INNER JOIN {menu_links} ml ON b.mlid = ml.mlid WHERE b.nid IN (:nids)", array(':nids' =>  array_keys($nodes)), array('fetch' => PDO::FETCH_ASSOC));
-    foreach ($result as $record) {
-      $nodes[$record['nid']]->book = $record;
-      $nodes[$record['nid']]->book['href'] = $record['link_path'];
-      $nodes[$record['nid']]->book['title'] = $record['link_title'];
-      $nodes[$record['nid']]->book['options'] = unserialize($record['options']);
-    }
+  $result = db_query("SELECT * FROM {book} b INNER JOIN {menu_links} ml ON b.mlid = ml.mlid WHERE b.nid IN (:nids)", array(':nids' =>  array_keys($nodes)), array('fetch' => PDO::FETCH_ASSOC));
+  foreach ($result as $record) {
+    $nodes[$record['nid']]->book = $record;
+    $nodes[$record['nid']]->book['href'] = $record['link_path'];
+    $nodes[$record['nid']]->book['title'] = $record['link_title'];
+    $nodes[$record['nid']]->book['options'] = unserialize($record['options']);
   }
 }
 


### PR DESCRIPTION
Update from Drupal 7.93 to Drupal 7.94.

Before merging this PR, check the [build results on CircleCI](https://circleci.com/gh/pantheon-systems/drops-7), and then visit the test site and confirm that the correct version of Drupal was, in fact, installed and tested.

Optionally, you may also create your own test site:

  - Create a new Drupal 7 site on Pantheon.
  - When site creation is finished, visit dashboard.
  - Switch to "git" mode.
  - Clone your site locally.
  - Apply the files from this PR on top of your local checkout.
    - git remote add drops-7 git@github.com:pantheon-systems/drops-7.git
    - git fetch drops-7
    - git merge drops-7/update-7.94
  - Push your files back up to Pantheon.
  - Switch back to sftp mode.
  - Visit your site and step through the installation process.
