### PR TITLE
Update to Drupal 7.95. For more information, see https://www.drupal.org/project/drupal/releases/7.95

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,8 @@
+Drupal 7.95, 2023-03-15
+-----------------------
+- Fixed security issues:
+   - SA-CORE-2023-004
+
 Drupal 7.94, 2022-12-14
 -----------------------
 - Hotfix for book.module and Select query properties

--- a/includes/bootstrap.inc
+++ b/includes/bootstrap.inc
@@ -8,7 +8,7 @@
 /**
  * The current system version.
  */
-define('VERSION', '7.94');
+define('VERSION', '7.95');
 
 /**
  * Core API compatibility.

--- a/modules/system/system.admin.inc
+++ b/modules/system/system.admin.inc
@@ -2385,7 +2385,7 @@ function system_run_cron() {
  * Menu callback: return information about PHP.
  */
 function system_php() {
-  phpinfo();
+  phpinfo(~ (INFO_VARIABLES | INFO_ENVIRONMENT));
   drupal_exit();
 }
 


### PR DESCRIPTION
Update from Drupal 7.94 to Drupal 7.95.

Before merging this PR, check the [build results on CircleCI](https://circleci.com/gh/pantheon-systems/drops-7), and then visit the test site and confirm that the correct version of Drupal was, in fact, installed and tested.

Optionally, you may also create your own test site:

  - Create a new Drupal 7 site on Pantheon.
  - When site creation is finished, visit dashboard.
  - Switch to "git" mode.
  - Clone your site locally.
  - Apply the files from this PR on top of your local checkout.
    - git remote add drops-7 git@github.com:pantheon-systems/drops-7.git
    - git fetch drops-7
    - git merge drops-7/update-7.95
  - Push your files back up to Pantheon.
  - Switch back to sftp mode.
  - Visit your site and step through the installation process.
