### PR TITLE
Update to Drupal 7.96. For more information, see https://www.drupal.org/project/drupal/releases/7.96

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,8 @@
+Drupal 7.96, 2023-04-19
+-----------------------
+- Fixed security issues:
+   - SA-CORE-2023-005
+
 Drupal 7.95, 2023-03-15
 -----------------------
 - Fixed security issues:

--- a/includes/bootstrap.inc
+++ b/includes/bootstrap.inc
@@ -8,7 +8,7 @@
 /**
  * The current system version.
  */
-define('VERSION', '7.95');
+define('VERSION', '7.96');
 
 /**
  * Core API compatibility.

--- a/includes/file.inc
+++ b/includes/file.inc
@@ -2077,6 +2077,7 @@ function file_download() {
   $scheme = array_shift($args);
   $target = implode('/', $args);
   $uri = $scheme . '://' . $target;
+  $uri = file_uri_normalize_dot_segments($uri);
   if (file_stream_wrapper_valid_scheme($scheme) && file_exists($uri)) {
     $headers = file_download_headers($uri);
     if (count($headers)) {
@@ -2732,6 +2733,58 @@ function file_get_content_headers($file) {
     'Content-Length' => $file->filesize,
     'Cache-Control' => 'private',
   );
+}
+
+/**
+ * Normalize dot segments in a URI.
+ *
+ * @param $uri
+ *   A stream, referenced as "scheme://target".
+ *
+ * @return string
+ *   The URI with dot segments removed and slashes as directory separator.
+ */
+function file_uri_normalize_dot_segments($uri) {
+  $scheme = file_uri_scheme($uri);
+
+  if (file_stream_wrapper_valid_scheme($scheme)) {
+    $target = file_uri_target($uri);
+
+    if ($target !== FALSE) {
+      if (!in_array($scheme, variable_get('file_sa_core_2023_005_schemes', array()))) {
+        $class = file_stream_wrapper_get_class($scheme);
+        $is_local = is_subclass_of($class, DrupalLocalStreamWrapper::class);
+        if ($is_local) {
+          $target = str_replace(DIRECTORY_SEPARATOR, '/', $target);
+        }
+
+        $parts = explode('/', $target);
+        $normalized_parts = array();
+        while ($parts) {
+          $part = array_shift($parts);
+          if ($part === '' || $part === '.') {
+            continue;
+          }
+          elseif ($part === '..' && $is_local && $normalized_parts === array()) {
+            $normalized_parts[] = $part;
+            break;
+          }
+          elseif ($part === '..') {
+            array_pop($normalized_parts);
+          }
+          else {
+            $normalized_parts[] = $part;
+          }
+        }
+
+        $target = implode('/', array_merge($normalized_parts, $parts));
+      }
+
+      $uri = $scheme . '://' . $target;
+    }
+  }
+
+  return $uri;
 }
 
 /**

--- a/modules/image/image.module
+++ b/modules/image/image.module
@@ -824,6 +824,20 @@ function image_style_deliver($style, $scheme = NULL) {
   array_shift($args);
   array_shift($args);
   $target = implode('/', $args);
+  $image_uri = $scheme . '://' . $target;
+  $image_uri = file_uri_normalize_dot_segments($image_uri);
+
+  if (file_stream_wrapper_valid_scheme($scheme)) {
+    $normalized_target = file_uri_target($image_uri);
+    if ($normalized_target !== FALSE) {
+      if (!in_array($scheme, variable_get('file_sa_core_2023_005_schemes', array()))) {
+        $parts = explode('/', $normalized_target);
+        if (array_intersect($parts, array('.', '..'))) {
+          return MENU_NOT_FOUND;
+        }
+      }
+    }
+  }
 
   // Check that the style is defined, the scheme is valid.
   $valid = !empty($style) && !empty($scheme) && file_stream_wrapper_valid_scheme($scheme);
@@ -835,7 +849,9 @@ function image_style_deliver($style, $scheme = NULL) {
   // variable from leaving the site vulnerable to the most serious attacks, a
   // token is always required when a derivative of a derivative is requested.)
   $token = isset($_GET[IMAGE_DERIVATIVE_TOKEN]) ? $_GET[IMAGE_DERIVATIVE_TOKEN] : '';
-  $token_is_valid = $token === image_style_path_token($style['name'], $scheme . '://' . $target);
+  $token_is_valid =
+    $token === image_style_path_token($style['name'], $image_uri)
+    || $token === image_style_path_token($style['name'], $scheme . '://' . $target);
   if (!variable_get('image_allow_insecure_derivatives', FALSE) || strpos(ltrim($target, '\/'), 'styles/') === 0) {
     $valid = $valid && $token_is_valid;
   }
@@ -843,7 +859,6 @@ function image_style_deliver($style, $scheme = NULL) {
     return MENU_ACCESS_DENIED;
   }
 
-  $image_uri = $scheme . '://' . $target;
   $derivative_uri = image_style_path($style['name'], $image_uri);
   $derivative_scheme = file_uri_scheme($derivative_uri);
 
@@ -1089,9 +1104,11 @@ function image_style_flush($style) {
  */
 function image_style_url($style_name, $path) {
   $uri = image_style_path($style_name, $path);
+  $uri = file_uri_normalize_dot_segments($uri);
 
   // The passed-in $path variable can be either a relative path or a full URI.
   $original_uri = file_uri_scheme($path) ? file_stream_wrapper_uri_normalize($path) : file_build_uri($path);
+  $original_uri = file_uri_normalize_dot_segments($original_uri);
 
   // The token query is added even if the 'image_allow_insecure_derivatives'
   // variable is TRUE, so that the emitted links remain valid if it is changed

--- a/modules/system/system.module
+++ b/modules/system/system.module
@@ -4093,6 +4093,25 @@ function system_admin_paths() {
  * Implements hook_file_download().
  */
 function system_file_download($uri) {
+  $scheme = file_uri_scheme($uri);
+  if (file_stream_wrapper_valid_scheme($scheme)) {
+    $target = file_uri_target($uri);
+    if ($target !== FALSE) {
+      if (!in_array($scheme, variable_get('file_sa_core_2023_005_schemes', array()))) {
+        if (DIRECTORY_SEPARATOR !== '/') {
+          $class = file_stream_wrapper_get_class($scheme);
+          if (is_subclass_of($class, DrupalLocalStreamWrapper::class)) {
+            $target = str_replace(DIRECTORY_SEPARATOR, '/', $target);
+          }
+        }
+        $parts = explode('/', $target);
+        if (array_intersect($parts, array('.', '..'))) {
+          return -1;
+        }
+      }
+    }
+  }
+
   $core_schemes = array('public', 'private', 'temporary');
   $additional_public_schemes = array_diff(variable_get('file_additional_public_schemes', array()), $core_schemes);
   if ($additional_public_schemes) {

--- a/sites/default/default.settings.php
+++ b/sites/default/default.settings.php
@@ -818,3 +818,22 @@ $conf['mail_display_name_site_name'] = TRUE;
  * Use this variable to set a custom cron lock expiration timeout (float).
  */
 # $conf['cron_lock_expiration_timeout'] = 900.0;
+
+/**
+ * File schemes whose paths should not be normalized:
+ *
+ * Normally, Drupal normalizes '/./' and '/../' segments in file URIs in order
+ * to prevent unintended file access. For example, 'private://css/../image.png'
+ * is normalized to 'private://image.png' before checking access to the file.
+ *
+ * On Windows, Drupal also replaces '\' with '/' in URIs for the local
+ * filesystem.
+ *
+ * If file URIs with one or more scheme should not be normalized like this, then
+ * list the schemes here. For example, if 'porcelain://china/./plate.png' should
+ * not be normalized to 'porcelain://china/plate.png', then add 'porcelain' to
+ * this array. In this case, make sure that the module providing the 'porcelain'
+ * scheme does not allow unintended file access when using '/../' to move up the
+ * directory tree.
+ */
+# $conf['file_sa_core_2023_005_schemes'] = array('porcelain');


### PR DESCRIPTION
Update from Drupal 7.95 to Drupal 7.96.

Before merging this PR, check the [build results on CircleCI](https://circleci.com/gh/pantheon-systems/drops-7), and then visit the test site and confirm that the correct version of Drupal was, in fact, installed and tested.

Optionally, you may also create your own test site:

  - Create a new Drupal 7 site on Pantheon.
  - When site creation is finished, visit dashboard.
  - Switch to "git" mode.
  - Clone your site locally.
  - Apply the files from this PR on top of your local checkout.
    - git remote add drops-7 git@github.com:pantheon-systems/drops-7.git
    - git fetch drops-7
    - git merge drops-7/update-7.96
  - Push your files back up to Pantheon.
  - Switch back to sftp mode.
  - Visit your site and step through the installation process.
