### PR TITLE
[BUGS-7554] Fix php 8.1 warning in Apache Solr module

### DIFF
--- a/modules/pantheon/pantheon_apachesolr/Pantheon_Apache_Solr_Service.php
+++ b/modules/pantheon/pantheon_apachesolr/Pantheon_Apache_Solr_Service.php
@@ -497,7 +497,7 @@ class PantheonApacheSolrService implements DrupalApacheSolrServiceInterface{
       list($result->protocol, $result->code, $result->status_message) = explode(' ', trim(array_shift($split)), 3);
       // Parse headers.
       $result->headers = array();
-      while ($line = trim(array_shift($split))) {
+      while (!empty($split) && $line = trim(array_shift($split))) {
         list($header, $value) = explode(':', $line, 2);
         if (isset($result->headers[$header]) && $header == 'Set-Cookie') {
           // RFC 2109: the Set-Cookie response header comprises the token Set-

--- a/modules/pantheon/pantheon_apachesolr/Pantheon_Search_Api_Solr_Service.php
+++ b/modules/pantheon/pantheon_apachesolr/Pantheon_Search_Api_Solr_Service.php
@@ -235,7 +235,7 @@ if (class_exists('Apache_Solr_HttpTransport_Abstract')) {
         list($result->protocol, $result->code, $result->status_message) = explode(' ', trim(array_shift($split)), 3);
         // Parse headers.
         $result->headers = array();
-        while ($line = trim(array_shift($split))) {
+        while (!empty($split) && $line = trim(array_shift($split))) {
           list($header, $value) = explode(':', $line, 2);
           if (isset($result->headers[$header]) && $result->header == 'Set-Cookie') {
             // RFC 2109: the Set-Cookie response header comprises the token Set-


### PR DESCRIPTION
Starting PHP 8.1, we started seeing the following warning from trim():
```
Deprecated function: trim(): Passing null to parameter #1 ($string) of type string is deprecated in PantheonApacheSolrService->_makeHttpRequest() (line 500 of /code/modules/pantheon/pantheon_apachesolr/Pantheon_Apache_Solr_Service.php).
```
Here we now check that the array_shifted variable is not empty first.