### PR TITLE
[CMSP-954] Update default PHP to 8.2

### DIFF
--- a/pantheon.upstream.yml
+++ b/pantheon.upstream.yml
@@ -3,7 +3,7 @@
 # Override the defaults specified here in a site-specific `pantheon.yml` file.
 # For more information see: https://pantheon.io/docs/pantheon-upstream-yml
 api_version: 1
-php_version: 8.1
+php_version: 8.2
 drush_version: 8
 
 # See https://pantheon.io/docs/pantheon-yml#specify-a-version-of-mariadb


### PR DESCRIPTION
Supported as of 7.92.

https://www.drupal.org/docs/7/system-requirements/php-requirements-for-drupal-7

----
Related: https://github.com/pantheon-systems/WordPress/pull/389
https://getpantheon.atlassian.net/browse/CMSP-954