### PR TITLE
Added properties to the class.

### DIFF
--- a/modules/pantheon/pantheon_apachesolr/Pantheon_Apache_Solr_Service.php
+++ b/modules/pantheon/pantheon_apachesolr/Pantheon_Apache_Solr_Service.php
@@ -104,7 +104,8 @@ class PantheonApacheSolrService implements DrupalApacheSolrServiceInterface{
   protected $luke;
   protected $stats;
   protected $system_info;
-
+  protected $system_info_cid;
+  protected $stats_cid;
 
   /**
    * Call the /admin/ping servlet, to test the connection to the server.


### PR DESCRIPTION
To avoid the depreciations warnings in PHP 8.2:

> Deprecated function: Creation of dynamic property PantheonApacheSolrService::$system_info_cid is deprecated in PantheonApacheSolrService->setSystemInfo() (line 149 of /code/modules/pantheon/pantheon_apachesolr/Pantheon_Apache_Solr_Service.php).