### PR TITLE
Allow support for SOLR 8.x in Drupal 7 set-up.

### DIFF
--- a/.circleci/.gitignore
+++ b/.circleci/.gitignore
@@ -1,0 +1,4 @@
+.DS_Store
+local.test
+local.env
+local.ssh

--- a/.circleci/behat.yml
+++ b/.circleci/behat.yml
@@ -1,0 +1,17 @@
+# behat.yml
+default:
+  suites:
+    default:
+      paths:
+        - features
+      contexts:
+        - Drupal\DrupalExtension\Context\DrupalContext
+        - Drupal\DrupalExtension\Context\MinkContext
+        - FeatureContext
+  extensions:
+    Behat\MinkExtension:
+      # base_url set by ENV
+      goutte: ~
+    Drupal\DrupalExtension:
+      blackbox: ~
+      api_driver: 'drush'

--- a/.circleci/cleanup.sh
+++ b/.circleci/cleanup.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# Echo commands as they are executed, but don't allow errors to stop the script.
+set -x
+
+if [ -z "$TERMINUS_SITE" ] || [ -z "$TERMINUS_ENV" ]; then
+  echo "TERMINUS_SITE and TERMINUS_ENV environment variables must be set"
+  exit 1
+fi
+
+# Only delete old environments if there is a pattern defined to
+# match environments eligible for deletion. Otherwise, delete the
+# current multidev environment immediately.
+#
+# To use this feature, set MULTIDEV_DELETE_PATTERN to '^ci-' or similar
+# in the CI server environment variables.
+if [ -z "$MULTIDEV_DELETE_PATTERN" ] ; then
+  terminus env:delete $TERMINUS_SITE.$TERMINUS_ENV --delete-branch --yes
+  exit 0
+fi
+
+# List all but the newest two environments.
+OLDEST_ENVIRONMENTS=$(terminus env:list "$TERMINUS_SITE" --format=list | grep -v dev | grep -v test | grep -v live | sort -k2 | grep "$MULTIDEV_DELETE_PATTERN" | sed -e '$d' | sed -e '$d')
+
+# Exit if there are no environments to delete
+if [ -z "$OLDEST_ENVIRONMENTS" ] ; then
+  exit 0
+fi
+
+# Go ahead and delete the oldest environments.
+for ENV_TO_DELETE in $OLDEST_ENVIRONMENTS ; do
+  terminus env:delete $TERMINUS_SITE.$ENV_TO_DELETE --delete-branch --yes
+done

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,56 @@
+version: 2
+jobs:
+    test:
+        docker:
+          - image: quay.io/pantheon-public/build-tools-ci:8.x-php8.2
+        working_directory: ~/work/d7
+        environment:
+          TZ: "/usr/share/zoneinfo/America/Los_Angeles"
+          TERM: dumb
+          TERMINUS_SITE: ci-update-drops-7
+        steps:
+            - checkout
+            - run:
+                name: Set up environment
+                command: ./.circleci/set-up-globals.sh
+            - run:
+                name: Prepare
+                command: ./.circleci/prepare.sh
+            - run:
+                name: Test
+                command: ./.circleci/test.sh --strict
+            - run:
+                name: Cleanup
+                command: ./.circleci/cleanup.sh
+            - run:
+                name: Confirm that it is safe to merge
+                command: ./.circleci/confirm-safety.sh
+    merge:
+        docker:
+          - image: quay.io/getpantheon/upstream-update-build:1.x
+        working_directory: ~/work/d7
+        environment:
+          TZ: "/usr/share/zoneinfo/America/Los_Angeles"
+          TERM: dumb
+        steps:
+            - checkout
+            - add_ssh_keys:
+                fingerprints:
+                  - "f8:c0:e1:28:4d:f9:1a:01:aa:7f:d0:8c:f6:e1:e6:88"
+            - run:
+                # https://github.com/pantheon-systems/upstream-update-build/blob/1.x/bin/automerge.sh
+                name: Merge the default branch back to the master branch
+                command: automerge.sh
+
+workflows:
+  version: 2
+  drops7:
+    jobs:
+      - test
+      - merge:
+          requires:
+            - test
+          filters:
+            branches:
+              only:
+                - default

--- a/.circleci/confirm-safety.sh
+++ b/.circleci/confirm-safety.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+#
+# The purpose of this script is to examine the base branch that this PR is
+# set to merge into by usig the GitHub API. We are only querying a public
+# repo here, so we do not need to use the GITHUB_TOKEN.
+#
+
+# Exit if we are not running on Circle CI.
+if [ -z "$CIRCLECI" ] ; then
+  exit 0
+fi
+
+# We only need to make this check for branches forked from default (right) / master (wrong).
+# Skip the test for the default branch. (The .circleci directory will never be added to the master branch).
+if [ "$CIRCLE_BRANCH" == "default" ] ; then
+  exit 0
+fi
+
+# We cannot continue unless we have a pull request.
+if [ -z "$CIRCLE_PULL_REQUEST" ] ; then
+  echo "No CIRCLE_PULL_REQUEST defined; please create a pull request."
+  exit 1
+fi
+
+# CIRCLE_PULL_REQUEST=https://github.com/ORG/PROJECT/pull/NUMBER
+PR_NUMBER=$(echo $CIRCLE_PULL_REQUEST | sed -e 's#.*/pull/##')
+
+# Display the API call we are using
+echo curl https://api.github.com/repos/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/pulls/$PR_NUMBER
+
+base=$(curl https://api.github.com/repos/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/pulls/$PR_NUMBER 2>/dev/null | jq .base.ref)
+
+echo "The base branch is $base"
+
+# If the PR merges into 'default', then it is safe to merge.
+if [ "$base" == '"default"' ] ; then
+  echo "It is safe to merge this PR into the $base branch"
+  exit 0
+fi
+
+# Force a test failure if the PR's base is the master branch.
+if [ "$base" == '"master"' ] ; then
+  echo "ERROR: merging this PR into the $base branch is not allowed. Change the base branch for the PR to merge into the \"default\" branch instead."
+  exit 1
+fi
+
+echo "Merging probably okay, if you are merging one PR into another. Use caution; do not merge to the \"master\" branch."

--- a/.circleci/features/0-install.feature
+++ b/.circleci/features/0-install.feature
@@ -1,0 +1,10 @@
+Feature: Installer
+  In order to know that we can install the site via drush
+  As a website user
+  I need to be able to install a Drupal site
+
+  Scenario: Installer is ready
+    Given I have wiped the site
+    And I have reinstalled "CI Drops-7 [{site-name}.{env}]"
+    And I visit "/"
+    Then I should see "Welcome to CI Drops-7"

--- a/.circleci/features/bootstrap/FeatureContext.php
+++ b/.circleci/features/bootstrap/FeatureContext.php
@@ -1,0 +1,232 @@
+<?php
+
+use Behat\Behat\Context\Context;
+use Behat\Behat\Context\SnippetAcceptingContext;
+use Behat\Behat\Hook\Scope\BeforeScenarioScope;
+use Drupal\DrupalExtension\Context\MinkContext;
+use Behat\Gherkin\Node\PyStringNode;
+use Behat\Gherkin\Node\TableNode;
+
+use Drupal\DrupalExtension\Context\RawDrupalContext;
+
+/**
+ * Define application features from the specific context.
+ */
+class FeatureContext extends RawDrupalContext implements Context, SnippetAcceptingContext {
+  /**
+   * Initializes context.
+   * Every scenario gets its own context object.
+   *
+   * @param array $parameters
+   *   Context parameters (set them in behat.yml)
+   */
+  public function __construct(array $parameters = []) {
+    // Initialize your context here
+  }
+
+  /** @var \Drupal\DrupalExtension\Context\MinkContext */
+  private $minkContext;
+  /** @BeforeScenario */
+  public function gatherContexts(BeforeScenarioScope $scope)
+  {
+      $environment = $scope->getEnvironment();
+      $this->minkContext = $environment->getContext('Drupal\DrupalExtension\Context\MinkContext');
+  }
+
+//
+// Place your definition and hook methods here:
+//
+//  /**
+//   * @Given I have done something with :stuff
+//   */
+//  public function iHaveDoneSomethingWith($stuff) {
+//    doSomethingWith($stuff);
+//  }
+//
+
+    /**
+     * Fills in form field with specified id|name|label|value
+     * Example: And I enter the value of the env var "TEST_PASSWORD" for "edit-account-pass-pass1"
+     *
+     * @Given I enter the value of the env var :arg1 for :arg2
+     */
+    public function fillFieldWithEnv($value, $field)
+    {
+        $this->minkContext->fillField($field, getenv($value));
+    }
+
+    /**
+     * Checks, that option from select with specified id|name|label|value is selected.
+     *
+     * @Then the :arg1 option from :arg2 should be selected
+     */
+    public function theOptionFromShouldBeSelected($option, $select)
+    {
+        $selectField = $this->getSession()->getPage()->findField($select);
+        if (null === $selectField) {
+            throw new ElementNotFoundException($this->getSession(), 'select field', 'id|name|label|value', $select);
+        }
+
+        $optionField = $selectField->find('named', array(
+            'option',
+            $option,
+        ));
+
+        if (null === $optionField) {
+            throw new ElementNotFoundException($this->getSession(), 'select option field', 'id|name|label|value', $option);
+        }
+
+        if (!$optionField->isSelected()) {
+            throw new ExpectationException('Select option field with value|text "'.$option.'" is not selected in the select "'.$select.'"', $this->getSession());
+        }
+    }
+
+    /**
+     * @Given I have wiped the site
+     */
+    public function iHaveWipedTheSite()
+    {
+        $site = getenv('TERMINUS_SITE');
+        $env = getenv('TERMINUS_ENV');
+
+        passthru("terminus --yes env:wipe {$site}.{$env}");
+    }
+
+    /**
+     * @Given I have reinstalled :arg1
+     */
+    public function iHaveReinstalled($arg1)
+    {
+        $site = getenv('TERMINUS_SITE');
+        $env = getenv('TERMINUS_ENV');
+        $password = getenv('ADMIN_PASSWORD');
+
+        $replacements = [
+          '{site-name}' => $site,
+          '{env}' => $env,
+        ];
+
+        $arg1 = str_replace(array_keys($replacements), array_values($replacements), $arg1);
+
+        $cmd = "terminus --yes drush {$site}.{$env} -- site-install pantheon --yes --site-name=\"$arg1\" --account-name=admin";
+        if (!empty($password)) {
+          $cmd .= " --account-pass='$password'";
+        }
+
+        passthru($cmd);
+    }
+
+    /**
+     * @Given I have run the drush command :arg1
+     */
+    public function iHaveRunTheDrushCommand($arg1)
+    {
+        $site = getenv('TERMINUS_SITE');
+        $env = getenv('TERMINUS_ENV');
+
+        $return = '';
+        $output = array();
+        exec("terminus  --yes drush {$site}.{$env} -- --yes $arg1", $output, $return);
+        $output = implode("\n", $output);
+
+        if ($return) {
+          throw new Exception("Error running Drush command:\n$output");
+        }
+
+        print "$output";
+    }
+
+    /**
+     * @Given I have committed my changes with comment :arg1
+     */
+    public function iHaveCommittedMyChangesWithComment($arg1)
+    {
+        $site = getenv('TERMINUS_SITE');
+        $env = getenv('TERMINUS_ENV');
+
+        passthru("terminus --yes env:commit {$site}.{$env} --message='$arg1'");
+    }
+
+    /**
+     * @Given I wait :seconds seconds
+     */
+    public function iWaitSeconds($seconds)
+    {
+        sleep($seconds);
+    }
+
+    /**
+     * @When I print the page contents
+     */
+    public function iPrintThePageContents()
+    {
+        $content = $this->getSession()->getPage()->getContent();
+        print $content;
+    }
+
+    /**
+     * @Given I wait :seconds seconds or until I see :text
+     */
+    public function iWaitSecondsOrUntilISee($seconds, $text)
+    {
+        $errorNode = $this->spin( function($context) use($text) {
+            $node = $context->getSession()->getPage()->find('named', array('content', $text));
+            if (!$node) {
+              return false;
+            }
+            return $node->isVisible();
+        }, $seconds);
+
+        // Throw to signal a problem if we were passed back an error message.
+        if (is_object($errorNode)) {
+          throw new Exception("Error detected when waiting for '$text': " . $errorNode->getText());
+        }
+    }
+
+    // http://docs.behat.org/en/v2.5/cookbook/using_spin_functions.html
+    // http://mink.behat.org/en/latest/guides/traversing-pages.html#selectors
+    public function spin ($lambda, $wait = 60)
+    {
+        for ($i = 0; $i <= $wait; $i++)
+        {
+            if ($i > 0) {
+              sleep(1);
+            }
+
+            $debugContent = $this->getSession()->getPage()->getContent();
+            file_put_contents("/tmp/mink/debug-" . $i, "\n\n\n=================================\n$debugContent\n=================================\n\n\n");
+
+            try {
+                if ($lambda($this)) {
+                    return true;
+                }
+            } catch (Exception $e) {
+                // do nothing
+            }
+
+            // If we do not see the text we are waiting for, fail fast if
+            // we see a Drupal 8 error message pane on the page.
+            $node = $this->getSession()->getPage()->find('named', array('content', 'Error'));
+            if ($node) {
+              $errorNode = $this->getSession()->getPage()->find('css', '.messages--error');
+              if ($errorNode) {
+                return $errorNode;
+              }
+              $errorNode = $this->getSession()->getPage()->find('css', 'main');
+              if ($errorNode) {
+                return $errorNode;
+              }
+              return $node;
+            }
+        }
+
+        $backtrace = debug_backtrace();
+
+        throw new Exception(
+            "Timeout thrown by " . $backtrace[1]['class'] . "::" . $backtrace[1]['function'] . "()\n" .
+            $backtrace[1]['file'] . ", line " . $backtrace[1]['line']
+        );
+
+        return false;
+    }
+}

--- a/.circleci/features/content.feature
+++ b/.circleci/features/content.feature
@@ -1,0 +1,12 @@
+Feature: Create Content through Drupal Content UI
+  In order to know that the Drupal content UI is working
+  As a website user
+  I need to be able to add a basic page
+
+  @api
+  Scenario: Add a basic page
+    Given I am logged in as a user with the "administrator" role
+    And I am on "/node/add/page"
+    And I enter "Test Page" for "Title"
+    And I press "Save"
+    Then I should see "Basic page Test Page has been created."

--- a/.circleci/features/pagecache.feature
+++ b/.circleci/features/pagecache.feature
@@ -1,0 +1,10 @@
+Feature: Check for settings on the cache configuration page
+  In order to know that the site was installed from the pantheon profile
+  As a website administrator
+  I need to know that Pantheon's initial settings were applied by the installer
+
+  @api
+  Scenario: Check to see if the page cache setting is set
+    Given I am logged in as a user with the "administrator" role
+    And I am on "/admin/config/development/performance"
+    Then the "900" option from "page_cache_maximum_age" should be selected

--- a/.circleci/features/pantheonsolr.feature
+++ b/.circleci/features/pantheonsolr.feature
@@ -1,0 +1,10 @@
+Feature: Check for existance of Pantheon Solr module
+  In order to know that the site was installed from Pantheon's upstream
+  As a website user
+  I need to know that Pantheon's Solr module is available
+
+  @api
+  Scenario: Check to see if Pantheon Solr is available
+    Given I am logged in as a user with the "administrator" role
+    And I am on "/admin/modules"
+    Then I should see "Pantheon Apache Solr"

--- a/.circleci/features/phpversion.feature
+++ b/.circleci/features/phpversion.feature
@@ -1,0 +1,10 @@
+Feature: Check php version
+  In order to know that pantheon.upstream.yml is working
+  As a website user
+  I need to know that I am running the correct version of php
+
+  @api
+  Scenario: Check the php version in the phpinfo output
+    Given I am logged in as a user with the "administrator" role
+    And I am on "/admin/reports/status/php"
+    Then I should see "PHP Version 8.2."

--- a/.circleci/local.test.dist
+++ b/.circleci/local.test.dist
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Copy to local.test and customize
+circleci \
+  -e CIRCLE_BUILD_NUM=0 \
+  -e TERMINUS_TOKEN=$TERMINUS_TOKEN \
+  -e TERMINUS_SITE=$TERMINUS_SITE \
+  -e TERMINUS_ENV=ci-$CIRCLE_BUILD_NUM \
+  -e TERMINUS_HIDE_UPDATE_MESSAGE=1 \
+  -e WORDPRESS_ADMIN_USERNAME=admin \
+  -e WORDPRESS_ADMIN_PASSWORD=$ADMIN_PASSWORD \
+  build --job test

--- a/.circleci/prepare.sh
+++ b/.circleci/prepare.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+###
+# Prepare a Pantheon site environment for the Behat test suite, by pushing the
+# requested upstream branch to the environment.
+###
+
+set -ex
+
+if [ -z "$TERMINUS_SITE" ] || [ -z "$TERMINUS_ENV" ]; then
+	echo "TERMINUS_SITE and TERMINUS_ENV environment variables must be set"
+	exit 1
+fi
+
+###
+# Clean up old unused environments, and make sure the dev site is spun up.
+###
+terminus build:env:delete:ci -n "$TERMINUS_SITE" --keep=2 --yes
+terminus env:wake -n "$TERMINUS_SITE.dev"
+
+###
+# Create a new environment for this particular test run.
+###
+terminus build:env:create -n "$TERMINUS_SITE.dev" "$TERMINUS_ENV" --yes
+terminus connection:set "${TERMINUS_SITE}.${TERMINUS_ENV}" git
+echo "" >> pantheon.yml
+git add pantheon.yml
+git commit -m "no-op pantheon.yml"
+terminus build:env:push "${TERMINUS_SITE}.${TERMINUS_ENV}"
+
+terminus connection:set "${TERMINUS_SITE}.${TERMINUS_ENV}" sftp
+terminus env:wake -n "$TERMINUS_SITE.$TERMINUS_ENV"
+terminus drush -n "$TERMINUS_SITE.$TERMINUS_ENV" -- updatedb -y

--- a/.circleci/set-up-globals.sh
+++ b/.circleci/set-up-globals.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+# Create a local .ssh directory if needed & available
+SELF_DIRNAME="`dirname -- "$0"`"
+[ -d "$HOME/.ssh" ] || [ ! -d "$SELF_DIRNAME/local.ssh" ] || cp -R "$SELF_DIRNAME/local.ssh" "$HOME/.ssh"
+
+# If an admin password has not been defined, write one to ~/WORDPRESS_ADMIN_PASSWORD
+if [ ! -f ~/WORDPRESS_ADMIN_PASSWORD ] && [ -z "$WORDPRESS_ADMIN_PASSWORD" ] ; then
+  echo $(openssl rand -hex 8) > ~/WORDPRESS_ADMIN_PASSWORD
+fi
+
+# If an admin password has not been defined, read it from ~/WORDPRESS_ADMIN_PASSWORD
+if [ ! -f ~/WORDPRESS_ADMIN_PASSWORD ] && [ -z "$WORDPRESS_ADMIN_PASSWORD" ] ; then
+  WORDPRESS_ADMIN_PASSWORD="$(cat ~/WORDPRESS_ADMIN_PASSWORD)"
+fi
+
+#=====================================================================================================================
+# EXPORT needed environment variables
+#
+# Circle CI 2.0 does not yet expand environment variables so they have to be manually EXPORTed
+# Once environment variables can be expanded this section can be removed
+# See: https://discuss.circleci.com/t/unclear-how-to-work-with-user-variables-circleci-provided-env-variables/12810/11
+# See: https://discuss.circleci.com/t/environment-variable-expansion-in-working-directory/11322
+# See: https://discuss.circleci.com/t/circle-2-0-global-environment-variables/8681
+#=====================================================================================================================
+mkdir -p $(dirname $BASH_ENV)
+touch $BASH_ENV
+(
+  echo 'export PATH=$PATH:$HOME/bin'
+  echo 'export TERMINUS_HIDE_UPDATE_MESSAGE=1'
+  echo 'export TERMINUS_ENV=ci-$CIRCLE_BUILD_NUM'
+  echo 'export WORDPRESS_ADMIN_USERNAME=pantheon'
+  echo "export WORDPRESS_ADMIN_PASSWORD=$WORDPRESS_ADMIN_PASSWORD"
+) >> $BASH_ENV
+source $BASH_ENV
+
+echo "Test site is $TERMINUS_SITE.$TERMINUS_ENV"
+echo "Logging in with a machine token:"
+terminus auth:login -n --machine-token="$TERMINUS_TOKEN"
+terminus whoami
+touch $HOME/.ssh/config
+echo "StrictHostKeyChecking no" >> "$HOME/.ssh/config"
+git config --global user.email "$GIT_EMAIL"
+git config --global user.name "Circle CI"
+# Ignore file permissions.
+git config --global core.fileMode false

--- a/.circleci/test.sh
+++ b/.circleci/test.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+###
+# Execute the Behat test suite against a prepared Pantheon site environment.
+###
+
+set -ex
+
+SELF_DIRNAME="`dirname -- "$0"`"
+
+# Require a target site
+if [ -z "$TERMINUS_SITE" ] || [ -z "$TERMINUS_ENV" ]; then
+	echo "TERMINUS_SITE and TERMINUS_ENV environment variables must be set"
+	exit 1
+fi
+
+# Check for rejection file and exit if one exists
+REJ_FILES=(`find . -type f -name '*.rej'`)
+if [ ${#REJ_FILES[@]} -gt 0 ]; then
+	echo "Merge conflict detected"
+	exit 1
+fi
+
+PATH=$PATH:~/.composer/vendor/bin
+
+# Create a drush alias file so that Behat tests can be executed against Pantheon.
+terminus aliases
+# Drush Behat driver fails without this option.
+echo "\$options['strict'] = 0;" >> ~/.drush/pantheon.aliases.drushrc.php
+
+export BEHAT_PARAMS='{"extensions" : {"Behat\\MinkExtension" : {"base_url" : "http://'$TERMINUS_ENV'-'$TERMINUS_SITE'.pantheonsite.io/"}, "Drupal\\DrupalExtension" : {"drush" :   {  "alias":  "@pantheon.'$TERMINUS_SITE'.'$TERMINUS_ENV'" }}}}'
+
+# We expect 'behat' to be in our PATH. Our container symlinks it at /usr/local/bin
+cd $SELF_DIRNAME && behat --config=behat.yml $*

--- a/.github/update_tag1_d7es.sh
+++ b/.github/update_tag1_d7es.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+set -euo pipefail
+
+main() {
+  # Variables
+  local MODULE_NAME="tag1_d7es"
+  local PANTHEON_UPSTREAM_DIR="modules/pantheon/$MODULE_NAME"
+  local PR_BASE_BRANCH="default"
+  local CURRENT_VERSION
+  local LATEST_VERSION
+  local TEMP_BRANCH
+  TEMP_BRANCH="update-$MODULE_NAME-$(date +%Y%m%d%H%M%S)"
+
+  # With these credentials, commits will be pushed to 'master' and available on
+  # the upstream immediately.
+  local GIT_USER="bot@getpantheon.com"
+  local GIT_NAME="Pantheon Automation"
+
+  local RELEASE_HISTORY_URL="https://updates.drupal.org/release-history/${MODULE_NAME}/7.x"
+  LATEST_VERSION=$(curl -s "$RELEASE_HISTORY_URL" \
+    | grep -oE '<version>[0-9a-zA-Z\.\-]+' \
+    | sed 's/<version>//' \
+    | grep -vE '(-rc|-beta|-alpha)' \
+    | sort -V | tail -n 1
+  )
+
+  CURRENT_VERSION=$(grep '^version' "${PANTHEON_UPSTREAM_DIR}/tag1_d7es.info" \
+    | awk -F' = ' '{print $2}' | tr -d '"'
+  )
+
+  echo "Current: ${CURRENT_VERSION}"
+  echo "Latest: ${LATEST_VERSION}"
+
+  if [ "$LATEST_VERSION" == "$CURRENT_VERSION" ]; then
+    echo "Already up to date."
+    exit 0
+  fi
+
+  local PR_TITLE="Update $MODULE_NAME to version $LATEST_VERSION"
+  local PR_EXISTS
+  PR_EXISTS=$(gh pr list --state open --search "$LATEST_VERSION" --json title \
+    | jq --arg pr_title "$PR_TITLE" '.[] | select(.title | contains($pr_title))'
+  )
+
+  if [ -n "$PR_EXISTS" ]; then
+    echo "A PR for version $LATEST_VERSION already exists. Skipping PR creation."
+    exit 0
+  fi
+
+  git checkout -b "$TEMP_BRANCH"
+
+  local DRUPAL_ORG_FTP_GZ_URL="https://ftp.drupal.org/files/projects/$MODULE_NAME-$LATEST_VERSION.tar.gz"
+  wget -qO- "$DRUPAL_ORG_FTP_GZ_URL" | tar -xz -C /tmp
+
+  rsync -ar --delete "/tmp/$MODULE_NAME/" "$PANTHEON_UPSTREAM_DIR/"
+  rm -rf "$PANTHEON_UPSTREAM_DIR/.github"
+  rm -f "$PANTHEON_UPSTREAM_DIR/.gitlab-ci.yml"
+  rm -rf "$PANTHEON_UPSTREAM_DIR/tests"
+
+  git config user.email "${GIT_USER}"
+  git config user.name "${GIT_NAME}"
+
+  git add "$PANTHEON_UPSTREAM_DIR"
+  git commit -m "Update $MODULE_NAME to version $LATEST_VERSION"
+  git push origin "$TEMP_BRANCH"
+
+  local PR_BODY="Updates the $MODULE_NAME module to version $LATEST_VERSION."
+  gh pr create --title "$PR_TITLE" \
+      --body "$PR_BODY" \
+      --head "$TEMP_BRANCH" \
+      --base "$PR_BASE_BRANCH"
+}
+
+main

--- a/.github/workflows/update_tag1_d7es.yml
+++ b/.github/workflows/update_tag1_d7es.yml
@@ -1,0 +1,24 @@
+
+on:
+  schedule:
+    - cron: '0 0 * * *' # Runs daily at midnight UTC
+  workflow_dispatch:
+
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  check-update:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Set up dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y jq wget curl
+      - name: Check and Update Module
+        run: .github/update_tag1_d7es.sh
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/modules/pantheon/pantheon_apachesolr/pantheon_apachesolr.module
+++ b/modules/pantheon/pantheon_apachesolr/pantheon_apachesolr.module
@@ -5,8 +5,16 @@
  *
  * Facilitates and debugs communication with Pantheon's Apache Solr service.
  */
-define('PANTHEON_APACHESOLR_PORT', variable_get('pantheon_index_port', 449));
-define('PANTHEON_APACHESOLR_HOST', variable_get('pantheon_index_host', 'index.'. variable_get('pantheon_tier', 'live') .'.getpantheon.com'));
+if (pantheon_apachesolr_get_search_version() == 8) {
+  $pantheon_apachesolr_host = getenv('PANTHEON_INDEX_HOST');
+  $pantheon_apachesolr_port = intval(getenv('PANTHEON_INDEX_PORT'));
+}
+else {
+  $pantheon_apachesolr_host = variable_get('pantheon_index_host', 'index.'. variable_get('pantheon_tier', 'live') .'.getpantheon.com');
+  $pantheon_apachesolr_port = variable_get('pantheon_index_port', 449);
+}
+define('PANTHEON_APACHESOLR_PORT', $pantheon_apachesolr_port);
+define('PANTHEON_APACHESOLR_HOST', $pantheon_apachesolr_host);
 
 /**
  * Implements hook_help().
@@ -166,6 +174,22 @@ function pantheon_apachesolr_platform_detected() {
 }
 
 /**
+ * Return 'true' if the Pantheon Search Version is detected.
+ * @return string
+ */
+function pantheon_apachesolr_search_version_detected() {
+  return isset($_ENV['search_version']);
+}
+
+/**
+ * Return Pantheon Search Version if detected.
+ * @return string
+ */
+function pantheon_apachesolr_get_search_version() {
+  return pantheon_apachesolr_search_version_detected() ? $_ENV['search_version'] : NULL;
+}
+
+/**
  * Return the path to the directory containing the certificates.
  */
 function pantheon_apachesolr_certs_dir() {
@@ -195,6 +219,8 @@ function pantheon_apachesolr_display_error_if_disabled() {
 }
 
 /**
+ * Posts the schema files to the SOLR server.
+ *
  * @param string $schema
  *   Path to local schema XML
  *
@@ -222,36 +248,84 @@ function pantheon_apachesolr_post_schema_exec($schema) {
   }
 
   $ch = curl_init();
-  $host = PANTHEON_APACHESOLR_HOST;
-  $path = 'sites/self/environments/'. variable_get('pantheon_environment', 'dev') .'/index';
+  if (pantheon_apachesolr_get_search_version() == 8) {
+    $host = PANTHEON_APACHESOLR_HOST;
+    $path = getenv('PANTHEON_INDEX_PATH') . getenv('PANTHEON_INDEX_SCHEMA');
 
-  $client_cert = pantheon_apachesolr_client_cert();
-  $url = 'https://'. $host .'/'. $path;
+    $client_cert = pantheon_apachesolr_client_cert();
+    $url = 'https://'. $host .'/'. $path;
 
-  $file = fopen($schema, 'r');
-  // set URL and other appropriate options
-  $opts = array(
-    CURLOPT_URL => $url,
-    CURLOPT_PORT => PANTHEON_APACHESOLR_PORT,
-    CURLOPT_RETURNTRANSFER => 1,
-    CURLOPT_SSLCERT => $client_cert,
-    CURLOPT_HTTPHEADER => array('Content-type:text/xml; charset=utf-8'),
-    CURLOPT_PUT => TRUE,
-    CURLOPT_BINARYTRANSFER => 1,
-    CURLOPT_INFILE => $file,
-    CURLOPT_INFILESIZE => filesize($schema),
-  );
-  curl_setopt_array($ch, $opts);
-  $response = curl_exec($ch);
-  $info = curl_getinfo($ch);
-  $success_codes = array(
-    '200',
-    '201',
-    '202',
-    '204'
-  );
-  $success = (in_array($info['http_code'], $success_codes));
-  fclose($file);
+    $schema_directory = dirname($schema);
+    $schema_files = scandir($schema_directory);
+    $files = array('files' => array());
+    foreach ($schema_files as $schema_file) {
+      if (!in_array($schema_file, array('.', '..'))) {
+        $files['files'][] = array(
+          'filename' => $schema_file,
+          'content' => base64_encode(file_get_contents($schema_directory . '/' . $schema_file)),
+        );
+      }
+    }
+    // Set URL and other appropriate options.
+    $opts = array(
+      CURLOPT_URL => $url,
+      CURLOPT_PORT => PANTHEON_APACHESOLR_PORT,
+      CURLOPT_RETURNTRANSFER => 1,
+      CURLOPT_SSLCERT => $client_cert,
+      CURLOPT_HTTPHEADER => array('ACCEPT:application/json', 'Content-type:application/json'),
+      CURLOPT_POST => TRUE,
+      CURLOPT_POSTFIELDS => json_encode($files),
+    );
+
+    curl_setopt_array($ch, $opts);
+    $response = curl_exec($ch);
+    $info = curl_getinfo($ch);
+    $success_codes = array(
+      '200',
+      '201',
+      '202',
+      '204'
+    );
+    $success = (in_array($info['http_code'], $success_codes));
+
+    if ($success) {
+      // Call reload on the server.
+      pantheon_apachesolr_reload_server_exec();
+    }
+  }
+  else {
+    $host = PANTHEON_APACHESOLR_HOST;
+    $path = 'sites/self/environments/'. variable_get('pantheon_environment', 'dev') .'/index';
+
+    $client_cert = pantheon_apachesolr_client_cert();
+    $url = 'https://'. $host .'/'. $path;
+
+    $file = fopen($schema, 'r');
+    // Set URL and other appropriate options.
+    $opts = array(
+      CURLOPT_URL => $url,
+      CURLOPT_PORT => PANTHEON_APACHESOLR_PORT,
+      CURLOPT_RETURNTRANSFER => 1,
+      CURLOPT_SSLCERT => $client_cert,
+      CURLOPT_HTTPHEADER => array('Content-type:text/xml; charset=utf-8'),
+      CURLOPT_PUT => TRUE,
+      CURLOPT_BINARYTRANSFER => 1,
+      CURLOPT_INFILE => $file,
+      CURLOPT_INFILESIZE => filesize($schema),
+    );
+
+    curl_setopt_array($ch, $opts);
+    $response = curl_exec($ch);
+    $info = curl_getinfo($ch);
+    $success_codes = array(
+      '200',
+      '201',
+      '202',
+      '204'
+    );
+    $success = (in_array($info['http_code'], $success_codes));
+    fclose($file);
+  }
   if (!$success) {
     watchdog('pantheon_apachesolr', 'Error !error posting !schema to !url', array(
       '!error' => curl_error($ch),
@@ -264,6 +338,46 @@ function pantheon_apachesolr_post_schema_exec($schema) {
   }
 
   return $success;
+}
+
+/**
+ * Reloads the SOLR server.
+ */
+function pantheon_apachesolr_reload_server_exec() {
+  if (!pantheon_apachesolr_platform_detected()) {
+    return;
+  }
+
+  $ch = curl_init();
+  $host = PANTHEON_APACHESOLR_HOST;
+  $path = getenv('PANTHEON_INDEX_PATH') . getenv('PANTHEON_INDEX_RELOAD_PATH');
+
+  $client_cert = pantheon_apachesolr_client_cert();
+  $url = 'https://'. $host .'/'. $path;
+
+  // Set URL and other appropriate options.
+  $opts = array(
+    CURLOPT_URL => $url,
+    CURLOPT_PORT => PANTHEON_APACHESOLR_PORT,
+    CURLOPT_RETURNTRANSFER => 1,
+    CURLOPT_SSLCERT => $client_cert,
+    CURLOPT_HTTPHEADER => array('ACCEPT:application/json', 'Content-type:application/json'),
+    CURLOPT_POST => TRUE,
+  );
+
+  curl_setopt_array($ch, $opts);
+  $response = curl_exec($ch);
+  $info = curl_getinfo($ch);
+  $success_codes = array(
+    '200',
+    '201',
+    '202',
+    '204'
+  );
+  $success = (in_array($info['http_code'], $success_codes));
+  if (!$success) {
+    watchdog('pantheon_apachesolr', 'Unable to reload Pantheon SOLR server.', WATCHDOG_ERROR);
+  }
 }
 
 /**
@@ -335,8 +449,14 @@ function pantheon_apachesolr_query($form, &$form_state) {
     );
   }
 
+
   $host = PANTHEON_APACHESOLR_HOST;
-  $path = 'sites/self/environments/'. variable_get('pantheon_environment', 'dev') .'/index';
+  if (pantheon_apachesolr_get_search_version() == 8) {
+    $path = getenv('PANTHEON_INDEX_PATH') . getenv('PANTHEON_INDEX_CORE');
+  }
+  else {
+    $path = 'sites/self/environments/'. variable_get('pantheon_environment', 'dev') .'/index';
+  }
   $url = 'https://'. $host .'/'. $path;
 
   $form['query_string'] = array(
@@ -369,7 +489,12 @@ function pantheon_apachesolr_query_submit($form, &$form_state) {
   $form_state['rebuild'] = TRUE;
 
   $host = PANTHEON_APACHESOLR_HOST;
-  $path = 'sites/self/environments/'. variable_get('pantheon_environment', 'dev') .'/index';
+  if (pantheon_apachesolr_get_search_version() == 8) {
+    $path = getenv('PANTHEON_INDEX_PATH') . getenv('PANTHEON_INDEX_CORE');
+  }
+  else {
+    $path = 'sites/self/environments/'. variable_get('pantheon_environment', 'dev') .'/index';
+  }
   $url = 'https://'. $host .'/'. $path . $form_state['values']['query'];
 
   $ch = curl_init();
@@ -428,12 +553,22 @@ function pantheon_apachesolr_post_schema_form($form, &$form_state) {
 
   $files = drupal_system_listing('/schema.*\.xml$/', 'modules', 'uri', 0);
   $schemas = array();
-  $recommended = '3.x/schema.xml';
+  if (pantheon_apachesolr_get_search_version() == 8) {
+    $recommended = '8.x/schema.xml';
+  }
+  else {
+    $recommended = '3.x/schema.xml';
+  }
+
   $wrong_versions = array(
     '4.x',
     '1.4',
     'extra',
   );
+  if (pantheon_apachesolr_get_search_version() == 8) {
+    $wrong_versions[] = '3.x';
+    $wrong_versions[] = '1.3';
+  }
 
   $default = '';
 
@@ -451,19 +586,41 @@ function pantheon_apachesolr_post_schema_form($form, &$form_state) {
       }
     }
 
-    if (!$recommended && in_array($data->uri, array(
-      'sites/all/modules/apachesolr/solr-conf/solr-3.x/schema.xml',
-      'sites/all/modules/search_api_solr/solr-conf/3.x/schema.xml',
-    ))) {
+    if (pantheon_apachesolr_get_search_version() == 8) {
+      $uris = array(
+        'sites/all/modules/apachesolr/solr-conf/solr-8.x/schema.xml',
+        'sites/all/modules/search_api_solr/solr-conf/8.x/schema.xml',
+      );
+    }
+    else {
+      $uris = array(
+        'sites/all/modules/apachesolr/solr-conf/solr-3.x/schema.xml',
+        'sites/all/modules/search_api_solr/solr-conf/3.x/schema.xml',
+      );
+    }
+
+    if (!$recommended && in_array($data->uri, $uris)) {
       $recommended = $data->uri;
     }
   }
   asort($schemas);
 
+  if (pantheon_apachesolr_get_search_version() == 8) {
+    $translate_parameters = array(
+      '@version' => 'v8.11.0',
+      '@schema' => '8.x/schema.xml',
+    );
+  }
+  else {
+    $translate_parameters = array(
+      '@version' => 'v3.5.0',
+      '@schema' => '3.x/schema.xml',
+    );
+  }
   $form['schemas'] = array(
     '#type' => 'fieldset',
     '#title' => t('Solr Schema File'),
-    '#description' => t('The following schema.xml files exist in your Drupal site code. Pantheon uses Apache Solr v3.5.0, so you should use 3.x/schema.xml as the base configuration.') . '<br/><br/>',
+    '#description' => t('The following schema.xml files exist in your Drupal site code. Pantheon uses Apache Solr @version, so you should use @schema as the base configuration.', $translate_parameters) . '<br/><br/>',
     '#weight' => -10,
   );
   if (count($schemas) > 0) {
@@ -548,7 +705,12 @@ function pantheon_apachesolr_status($form, &$form_state) {
   );
 
   // Ping.
-  $path = 'sites/self/environments/' . variable_get('pantheon_environment', 'dev') . '/index/admin/ping';
+  if (pantheon_apachesolr_get_search_version() == 8) {
+    $path = getenv('PANTHEON_INDEX_PATH') . getenv('PANTHEON_INDEX_CORE') . '/admin/ping';
+  }
+  else {
+    $path = 'sites/self/environments/' . variable_get('pantheon_environment', 'dev') . '/index/admin/ping';
+  }
 
   if ($schema == 'search_api_solr') {
     $path .= '?q=id:1';
@@ -628,7 +790,12 @@ function pantheon_apachesolr_status($form, &$form_state) {
   }
 
   // Solr Stats.
-  $path = 'sites/self/environments/' . variable_get('pantheon_environment', 'dev') . '/index/admin/stats.jsp';
+  if (pantheon_apachesolr_get_search_version() == 8) {
+    $path = getenv('PANTHEON_INDEX_PATH') . getenv('PANTHEON_INDEX_CORE') . '/admin/system';
+  }
+  else {
+    $path = 'sites/self/environments/' . variable_get('pantheon_environment', 'dev') . '/index/admin/stats.jsp';
+  }
   $url = 'https://'. $host . '/' . $path;
 
   $ch = curl_init();
@@ -642,12 +809,22 @@ function pantheon_apachesolr_status($form, &$form_state) {
 
   $response = curl_exec($ch);
   curl_close($ch);
-  $oXML = new SimpleXMLElement($response);
 
-  $debug = array(
-    t('Core') => $oXML->core,
-    t('Schema') => $oXML->schema,
-  );
+  if (pantheon_apachesolr_get_search_version() == 8) {
+    $info = json_decode($response, TRUE);
+    $debug = array(
+      t('Core') => str_replace('/var/solr/data/', '', $info['core']['directory']['instance']),
+      t('Schema') => $info['core']['schema'],
+    );
+  }
+  else {
+    $oXML = new SimpleXMLElement($response);
+
+    $debug = array(
+      t('Core') => $oXML->core,
+      t('Schema') => $oXML->schema,
+    );
+  }
 
   $debug_str = '<h2>' . t('Core and Schema from Solr Server') . '</h2>';
   $debug_str .= '<dl>';
@@ -723,7 +900,12 @@ function pantheon_apachesolr_requirements($phase) {
       ));
       // Ping.
       $host = PANTHEON_APACHESOLR_HOST;
-      $path = 'sites/self/environments/' . variable_get('pantheon_environment', 'dev') . '/index/admin/ping';
+      if (pantheon_apachesolr_get_search_version() == 8) {
+        $path = getenv('PANTHEON_INDEX_PATH') . getenv('PANTHEON_INDEX_CORE') . '/admin/ping';
+      }
+      else {
+        $path = 'sites/self/environments/' . variable_get('pantheon_environment', 'dev') . '/index/admin/ping';
+      }
       $schema = strpos($pantheon_apachesolr_schema, 'search_api_solr') !== FALSE ? 'search_api_solr' : 'generic';
 
       if ($schema == 'search_api_solr') {


### PR DESCRIPTION
Allow support for SOLR 8.x support in Drupal 7 set-up.

Before merging this PR, check the [build results on CircleCI](https://circleci.com/gh/pantheon-systems/drops-7), and then visit the test site and confirm that the correct version of Drupal was, in fact, installed and tested.

Optionally, you may also create your own test site:

- Create a new Drupal 7 site on Pantheon.
- When site creation is finished, visit dashboard.
- Switch to "git" mode.
- Clone your site locally.
- Apply the files from this PR on top of your local checkout.
  - git remote add drops-7 [git@github.com](mailto:git@github.com):pantheon-systems/drops-7.git
  - git fetch drops-7
  - git merge drops-7/update-7.95
- Push your files back up to Pantheon.
- Switch back to sftp mode.
- Visit your site and step through the installation process.

# Setting Up SOLR 8.x in Drupal 7 From Scratch

- Install the following modules (use the latest versions if needed):
  - Chaos Tools Suite version: 7.x-1.21 
  - Entity API version: 7.x-1.11
  - Search API version: 7.x-1.29
  - Search API Solr version: 7.x-1.16 
- Request Pantheon to remove the Git hook blocking the use of SOLR 8 in Upstream Drupal 7 sites. This is assuming Pantheon has not removed this block globally yet.
- Update Upstream to use SOLR 8, once the previous step is done.
- Push your files back up to Pantheon.
- In your site, enable the following modules:
  - Pantheon Apache Solr
  - Pantheon Platform API
  - Search API
  - Search API Solr (If not yet incorporated to the latest version, apply the patch found in https://www.drupal.org/project/search_api_solr/issues/3254212#comment-16017066)
- Configure Pantheon Apache Solr (this can be skipped in outside Pantheon):
  - Configuration > Search and Metadata > Pantheon Apache Solr > Post schema.xml (tab)
  - Choose `sites/all/modules/contrib/search_api_solr/solr-conf/8.x/schema.xml (recommended)` and click `Post schema`.
  - After waiting for a few minutes confirm if the configuration is updated by checking the `Status` tab beside (left) the `Post schema.xml`.
  - Check some test queries by checking the `Execute query` tab beside (right) the `Post schema.xml`.
- Configure Search API or create new server and index configuration:
 - Configuration > Search and Metadata > Search API
   - Add a new server, using `Solr service` Service class.
   - Set configuration using this suggested values for Pantheon (change values accordingly if outside Pantheon):
     - HTTP protocol: https
     - Solr host: localhost
     - Solr port: 8983
     - Solr path: /solr   
   - Add a new server, using `Solr service` Service class.
   - Set configuration using this suggested values:
     - Enabled: true
     - Server: the new server created above.
     - The rest of the settings is based on user preference. I.e. `Index items immediately`, inclusive `Fields`, `Highlighting` in Filters.
- Index the contents, if there are any. 
- Create a Views display that uses the Indexing with an exposed filter for the query string.

Sample: https://dev-drupal7-solr.pantheonsite.io/search

# Switching from SOLR 3.x to SOLR 8.x in Drupal 7
- Update the site using the latest Drops 7 code base (with these code changes included). (Or at least the Pantheon project only inside the `modules `directory). 
- Apply the patch for Search API Solr (If not yet incorporated to the latest version, apply the patch found in https://www.drupal.org/project/search_api_solr/issues/3254212#comment-16017066).
- Assuming the pre-existing Drupal 7 site used the default SOLR configurations for 3.x, then it is assumed that the 8.x SOLR configurations should be used. If there are customizations use the template for 8.x and apply the customizations.
- Configure Pantheon Apache Solr:
  - Configuration > Search and Metadata > Pantheon Apache Solr > Post schema.xml (tab)
  - Choose `sites/all/modules/contrib/search_api_solr/solr-conf/8.x/schema.xml (recommended)` and click `Post schema`.
  - After waiting for a few minutes confirm if the configuration is updated by checking the `Status` tab beside (left) the `Post schema.xml`.
  - Check some test queries by checking the `Execute query` tab beside (right) the `Post schema.xml`.
- Run any pending Search API tasks if there are alerts to this effects.
- Reindex site contents.