### PR TITLE
[SITE-5456] Add  support for Solr 9 in D7

### DIFF
--- a/.github/scripts/solr9-bootstrap-fixture.sh
+++ b/.github/scripts/solr9-bootstrap-fixture.sh
@@ -1,0 +1,245 @@
+#!/usr/bin/env bash
+set -eou pipefail
+
+# Bootstrap a D7 Solr 9 CI fixture site from scratch.
+#
+# Recreates the full dev environment that Solr 9 CUJ tests depend on.
+# Run this if the fixture site is destroyed, corrupted, or needs to be
+# rebuilt from zero.
+#
+# What it sets up:
+#   1. Pantheon site on Drupal 7 upstream
+#   2. Solr add-on enabled
+#   3. Drupal install with admin credentials
+#   4. 20 article nodes with real, searchable content
+#   5. Verification
+#
+# Examples:
+#   .github/scripts/solr9-bootstrap-fixture.sh -n search-api-pantheon-d7 -o "<org-name-or-uuid>"
+#
+# Prerequisites:
+#   - terminus authenticated (terminus auth:whoami)
+
+show_help() {
+    echo "Usage: $0 -n <site-name> -o <org>"
+    echo "Options:"
+    echo "  -n <arg>         Site name (e.g. search-api-pantheon-d7)"
+    echo "  -o <arg>         Organization name or UUID (required)"
+    echo "  -h               Show help"
+}
+
+main() {
+    local SITE_NAME=""
+    local ORG=""
+
+    while getopts "n:o:h" opt; do
+        case $opt in
+            n) SITE_NAME="$OPTARG" ;;
+            o) ORG="$OPTARG" ;;
+            h) show_help; exit 0 ;;
+            *) show_help; exit 1 ;;
+        esac
+    done
+
+    shift "$((OPTIND-1))"
+
+    if [[ -z "$SITE_NAME" ]]; then
+        echo "ERROR: -n <site-name> is required"
+        show_help
+        exit 1
+    fi
+
+    if [[ -z "$ORG" ]]; then
+        echo "ERROR: -o <org> is required"
+        show_help
+        exit 1
+    fi
+
+    local SITE_NAME_LC
+    SITE_NAME_LC=$(echo "$SITE_NAME" | tr '[:upper:]' '[:lower:]')
+    local SITE_ENV="${SITE_NAME_LC}.dev"
+
+    echo "=== Bootstrap D7 Solr 9 CI Fixture Site ==="
+    echo "Site: ${SITE_NAME}"
+    echo "Org: ${ORG}"
+    echo ""
+
+    # -----------------------------------------------------------------------
+    # Step 1: Create site (exit if exists)
+    # -----------------------------------------------------------------------
+    if terminus site:info "$SITE_NAME_LC" &>/dev/null; then
+        echo "ERROR: Site ${SITE_NAME} already exists. Exiting to avoid modifying an existing site."
+        echo "Delete it first if you want to recreate: terminus site:delete ${SITE_NAME_LC}"
+        exit 1
+    fi
+
+    echo "[1/6] Creating site..."
+    terminus site:create "$SITE_NAME" "$SITE_NAME" "drupal7" --org="$ORG"
+    echo "Waiting for site creation workflow..."
+    terminus workflow:wait "$SITE_ENV"
+
+    local SITE_ID
+    SITE_ID=$(terminus site:info "$SITE_NAME_LC" --field=ID)
+
+    # -----------------------------------------------------------------------
+    # Step 2: Upgrade plan + enable Solr
+    # -----------------------------------------------------------------------
+    echo "[2/6] Configuring plan and Solr..."
+    local CURRENT_PLAN
+    CURRENT_PLAN=$(terminus site:info "$SITE_NAME_LC" --field=plan_name 2>/dev/null || echo "")
+    if [[ "$CURRENT_PLAN" == *"Sandbox"* ]]; then
+        echo "Upgrading to Performance Small..."
+        terminus plan:set "$SITE_ID" "plan-performance_small-contract-annual-1"
+    else
+        echo "[skip] Already on plan: ${CURRENT_PLAN}"
+    fi
+
+    echo "Enabling Solr..."
+    terminus solr:enable "$SITE_ID" 2>/dev/null || echo "[skip] Solr already enabled or enable failed"
+
+    # -----------------------------------------------------------------------
+    # Step 3: Set Solr version 9 in pantheon.yml (inherited by all multidevs)
+    # -----------------------------------------------------------------------
+    echo "[3/6] Setting Solr version 9 in pantheon.yml..."
+    # pantheon.yml changes are committed over git, so the env must be in git mode.
+    # A freshly created site defaults to SFTP mode, which rejects pushes.
+    terminus connection:set "$SITE_ENV" git
+    terminus workflow:wait "$SITE_ENV"
+    local GIT_URL
+    GIT_URL=$(terminus connection:info "$SITE_ENV" --field=git_url)
+    rm -rf /tmp/bootstrap-pantheon-site
+    GIT_SSH_COMMAND="ssh -o StrictHostKeyChecking=no" git clone "$GIT_URL" /tmp/bootstrap-pantheon-site
+    (
+        cd /tmp/bootstrap-pantheon-site
+        touch pantheon.yml
+        if grep -q "^search:" pantheon.yml; then
+            # sed -i.bak keeps this portable across GNU (Linux/GHA) and BSD (macOS) sed.
+            sed -i.bak "s/^\([[:space:]]*\)version: [0-9]*/\1version: 9/" pantheon.yml
+            rm -f pantheon.yml.bak
+        else
+            echo "search:" >> pantheon.yml
+            echo "  version: 9" >> pantheon.yml
+        fi
+        echo "pantheon.yml contents:"
+        cat pantheon.yml
+        git add pantheon.yml
+        # Only commit when there is a staged change. A real commit failure
+        # (e.g. gpg signing, pre-commit hook) must abort rather than be
+        # swallowed, otherwise the push silently lands nothing and the
+        # fixture ends up without search: version: 9.
+        if ! git diff --cached --quiet; then
+            git commit -m "Set Solr version to 9 for CUJ fixture"
+        else
+            echo "No changes to commit"
+        fi
+        git push origin HEAD
+    )
+    terminus workflow:wait "$SITE_ENV"
+    rm -rf /tmp/bootstrap-pantheon-site
+
+    # -----------------------------------------------------------------------
+    # Step 4: Install Drupal
+    # -----------------------------------------------------------------------
+    echo "[4/6] Installing Drupal..."
+    # site-install writes settings.php, which requires SFTP (read/write) mode.
+    # Git mode mounts the code read-only and the install fails with "Permission denied".
+    terminus connection:set "$SITE_ENV" sftp
+    terminus workflow:wait "$SITE_ENV"
+    local ADMIN_PASS
+    ADMIN_PASS=$(openssl rand -base64 18)
+    if terminus drush "$SITE_ENV" -- status --field=bootstrap 2>/dev/null | grep -q "Successful"; then
+        echo "[skip] Drupal already installed"
+    else
+        terminus drush "$SITE_ENV" -- site-install standard \
+            --site-name="D7 Solr 9 CI" \
+            --account-name=admin \
+            --account-pass="$ADMIN_PASS" \
+            -y
+    fi
+
+    # -----------------------------------------------------------------------
+    # Step 5: Create 20 article nodes with real content
+    # -----------------------------------------------------------------------
+    echo "[5/6] Creating article nodes..."
+
+    terminus drush "$SITE_ENV" -- ev '
+$articles = array(
+  array("Getting Started with Apache Solr on Pantheon", "Apache Solr is a powerful open-source search platform built on Apache Lucene. Pantheon provides managed Solr instances for every environment, enabling fast full-text search across your Drupal content. This guide covers initial setup, schema posting, and indexing your first batch of content."),
+  array("Understanding Drupal Content Types and Fields", "Drupal organizes content into types such as articles, pages, and custom bundles. Each content type can have fields for text, images, taxonomy references, and more. Properly structured content types improve both editorial workflow and search relevance."),
+  array("WordPress to Drupal Migration Best Practices", "Migrating from WordPress to Drupal requires careful planning around content mapping, URL redirects, and user account migration. The Migrate module provides a framework for pulling content from external sources including WordPress databases and XML exports."),
+  array("Performance Optimization for High Traffic Websites", "High traffic websites require careful attention to caching, database query optimization, and CDN configuration. Pantheon Global CDN provides edge caching with surrogate key purging, while Varnish handles full-page caching at the platform level."),
+  array("Search Engine Optimization Techniques for Drupal", "Effective SEO in Drupal involves clean URL structures, proper meta tag configuration, XML sitemaps, and structured data markup. The Pathauto module generates search-friendly URLs automatically based on content patterns."),
+  array("Configuring Multidev Environments on Pantheon", "Multidev environments allow teams to work on parallel feature branches without interfering with each other. Each multidev gets its own database, files, and server environment cloned from an existing environment."),
+  array("Database Backup and Recovery Strategies", "Regular database backups are essential for disaster recovery. Pantheon provides automated daily backups and on-demand backup creation. Recovery involves downloading the backup archive and importing it into the target environment."),
+  array("Custom Module Development in Drupal 7", "Building custom modules in Drupal 7 follows the hook system architecture. Modules implement hooks like hook_menu, hook_form_alter, and hook_node_view to extend core functionality. The module .info file declares dependencies and metadata."),
+  array("Solr Schema Configuration and Field Mapping", "The Solr schema defines how content fields are indexed and searched. Field types control tokenization, stemming, and analysis chains. Proper field mapping ensures that search queries return relevant results with appropriate boosting."),
+  array("Terminus Command Line Interface Reference", "Terminus is the command line interface for Pantheon. It provides commands for site management, environment operations, and workflow automation. Common commands include site creation, database operations, and deployment workflows."),
+  array("Managing SSL Certificates for Custom Domains", "Custom domains on Pantheon require DNS configuration and SSL certificate provisioning. The platform provides free automated HTTPS through Let us Encrypt. Proper DNS setup includes A records, CNAME records, and CAA records for certificate authority authorization."),
+  array("Cron Job Scheduling and Automation in Drupal", "Drupal cron runs periodic maintenance tasks including content indexing, cache clearing, and queue processing. On Pantheon, cron runs automatically every hour. Custom cron intervals can be configured using the Elysia Cron module or hook_cron implementations."),
+  array("User Authentication and Role Management", "Drupal provides a robust permission system with roles and granular access controls. Users can be assigned multiple roles, each granting specific permissions. SAML and OAuth integrations enable single sign-on with external identity providers."),
+  array("Responsive Theme Development with Drupal 7", "Building responsive themes in Drupal 7 requires media queries, fluid grids, and flexible images. The theme layer uses template files, preprocess functions, and the render API. Mobile-first design ensures optimal experience across devices."),
+  array("Version Control Workflows for Drupal Teams", "Git-based workflows on Pantheon support feature branching, code review, and automated deployments. Teams typically use a trunk-based development model with short-lived feature branches. Pull requests enable peer review before merging to the main branch."),
+  array("Debugging PHP Errors and Watchdog Logs", "Drupal watchdog logs capture errors, warnings, and informational messages from modules and core. The dblog module stores entries in the database accessible at admin reports dblog. Common PHP errors include undefined function calls, memory limits, and deprecated function usage."),
+  array("Taxonomy and Vocabulary Configuration Guide", "Taxonomy provides hierarchical classification for Drupal content. Vocabularies group related terms, and term references connect content to classification schemes. Faceted search leverages taxonomy to filter results by category, tag, or other classification dimensions."),
+  array("Integrating Third Party APIs with Drupal", "Drupal modules can consume external APIs using drupal_http_request or the Guzzle HTTP client. API keys and credentials should be stored securely using the Key module or environment variables. Rate limiting and caching prevent excessive API calls."),
+  array("Content Moderation and Editorial Workflows", "Editorial workflows in Drupal manage content through draft, review, and published states. The Workbench Moderation module provides configurable states and transitions. Role-based permissions control who can create, edit, and publish content at each stage."),
+  array("Redis Object Caching for Improved Performance", "Redis provides in-memory object caching that reduces database queries and improves page load times. Pantheon offers Redis as a platform service with automatic failover. The Redis module integrates Drupal cache bins with the Redis backend for persistent object storage."),
+);
+foreach ($articles as $a) {
+  $node = new stdClass();
+  $node->type = "article";
+  $node->title = $a[0];
+  $node->language = LANGUAGE_NONE;
+  $node->body[LANGUAGE_NONE][0] = array("value" => $a[1], "format" => "filtered_html");
+  $node->status = 1;
+  $node->promote = 1;
+  node_save($node);
+  echo "Created: " . $node->title . "\n";
+}
+'
+
+    # -----------------------------------------------------------------------
+    # Step 6: Verify setup
+    # -----------------------------------------------------------------------
+    echo "[6/6] Verifying setup..."
+
+    # Capture output and assert on a success marker rather than trusting the
+    # drush PHP exit code to propagate through terminus.
+    local VERIFY_OUT
+    VERIFY_OUT=$(terminus drush "$SITE_ENV" -- ev '
+$count = db_query("SELECT COUNT(*) FROM {node}")->fetchField();
+if ($count < 20) {
+  echo "FAIL: Expected 20 nodes, found " . $count . "\n";
+  exit(1);
+}
+echo "Node count: " . $count . " (OK)\n";
+
+$solr_check = db_query("SELECT COUNT(*) FROM {node} WHERE title LIKE :pattern", array(":pattern" => "%Solr%"))->fetchField();
+echo "Nodes containing Solr: " . $solr_check . "\n";
+
+$terminus_check = db_query("SELECT COUNT(*) FROM {node} WHERE title LIKE :pattern", array(":pattern" => "%Terminus%"))->fetchField();
+echo "Nodes containing Terminus: " . $terminus_check . "\n";
+' 2>&1)
+    echo "$VERIFY_OUT"
+    if ! echo "$VERIFY_OUT" | grep -q "(OK)"; then
+        echo "ERROR: Verification failed (expected 20 nodes)."
+        exit 1
+    fi
+
+    echo ""
+    echo "=== Bootstrap complete ==="
+    echo "Site: ${SITE_NAME_LC}"
+    echo "Site ID: ${SITE_ID}"
+    echo "Dev URL: https://dev-${SITE_NAME_LC}.pantheonsite.io"
+    echo "Admin: admin / ${ADMIN_PASS}"
+    echo "(generated; re-login any time with: terminus drush ${SITE_ENV} -- uli)"
+    echo ""
+    echo "Next steps:"
+    echo "  1. Add TERMINUS_TOKEN, PANTHEON_SSH_KEY secrets to the drops-7 repo"
+    echo "  2. Add PANTHEON_SITE_D7 repo variable = ${SITE_NAME_LC}"
+    echo ""
+    echo "CI multidevs will inherit article content from dev."
+    echo "Modules (apachesolr, search_api_solr) are installed per-multidev by solr9-setup-multidev.sh."
+}
+
+main "$@"

--- a/.github/scripts/solr9-cuj6-configure-server.sh
+++ b/.github/scripts/solr9-cuj6-configure-server.sh
@@ -1,0 +1,151 @@
+#!/bin/bash
+set -euo pipefail
+
+# CUJ 6: Configure a Solr Server
+# Tests that the search module can connect to Solr 9 after schema posting.
+# Accepts MODULE env var: apachesolr or search_api_solr
+
+SITE_ENV="${TERMINUS_SITE}.${MULTIDEV}"
+MODULE="${MODULE:?MODULE env var must be set}"
+
+# shellcheck source=.github/scripts/solr9-shared.sh
+source "$(dirname "$0")/solr9-shared.sh"
+
+step "CUJ 6: Configure Solr Server ($MODULE)"
+
+if [ "$MODULE" = "apachesolr" ]; then
+  SCHEMA_PATH="sites/all/modules/apachesolr/solr-conf/solr-9.x/schema.xml"
+elif [ "$MODULE" = "search_api_solr" ]; then
+  SCHEMA_PATH="sites/all/modules/search_api_solr/solr-conf/9.x/schema.xml"
+else
+  echo "::error::Unknown module: $MODULE"
+  exit 1
+fi
+
+step "Step 1: Post Solr 9 schema ($SCHEMA_PATH)"
+
+MAX_RETRIES=3
+RETRY_DELAY=60
+for attempt in $(seq 1 $MAX_RETRIES); do
+  echo "Schema post attempt $attempt of $MAX_RETRIES..."
+  RESULT=$(drush_ev "
+    variable_set('pantheon_apachesolr_schema', '$SCHEMA_PATH');
+    \$result = pantheon_apachesolr_post_schema_exec('$SCHEMA_PATH');
+    echo \$result ? 'SCHEMA_POSTED' : 'SCHEMA_FAILED';
+  ") || true
+
+  if echo "$RESULT" | grep -q "SCHEMA_POSTED"; then
+    echo "Schema posted successfully."
+    break
+  fi
+
+  if [ "$attempt" -lt "$MAX_RETRIES" ]; then
+    echo "Schema post failed, retrying in ${RETRY_DELAY}s..."
+    sleep "$RETRY_DELAY"
+  else
+    echo "::error::Schema post failed after $MAX_RETRIES attempts."
+    exit 1
+  fi
+done
+
+step "Step 2: Verify Solr ping"
+
+PING_RESULT=$(drush_ev "
+  \$host = PANTHEON_APACHESOLR_HOST;
+  \$path = getenv('PANTHEON_INDEX_PATH') . getenv('PANTHEON_INDEX_CORE') . '/admin/ping';
+  if ('$MODULE' === 'search_api_solr') {
+    \$path .= '?q=id:1';
+  }
+  \$url = 'https://' . \$host . '/' . \$path;
+  list(\$ch, \$opts) = pantheon_apachesolr_curl_setup(\$url, PANTHEON_APACHESOLR_PORT);
+  \$opts = pantheon_apachesolr_curlopts(\$opts);
+  \$opts[CURLOPT_CONNECTTIMEOUT] = 5;
+  \$opts[CURLOPT_RETURNTRANSFER] = 1;
+  curl_setopt_array(\$ch, \$opts);
+  \$response = curl_exec(\$ch);
+  \$info = curl_getinfo(\$ch);
+  curl_close(\$ch);
+  echo (\$response !== FALSE && in_array(\$info['http_code'], array(200, 201, 202, 204))) ? 'PING_OK' : 'PING_FAILED:' . \$info['http_code'];
+") || true
+
+if echo "$PING_RESULT" | grep -q "PING_OK"; then
+  echo "Solr ping successful."
+else
+  echo "::error::Solr ping failed: $PING_RESULT"
+  exit 1
+fi
+
+step "Step 3: Module-specific verification"
+
+if [ "$MODULE" = "apachesolr" ]; then
+  ENV_CHECK=$(drush_ev "
+    \$env_id = apachesolr_default_environment();
+    if (\$env_id) {
+      \$env = apachesolr_environment_load(\$env_id);
+      echo 'ENV_OK:' . \$env['url'];
+    } else {
+      echo 'ENV_MISSING';
+    }
+  ") || true
+
+  if echo "$ENV_CHECK" | grep -q "ENV_OK"; then
+    echo "Apache Solr default environment configured."
+  else
+    echo "::error::Apache Solr default environment not found"
+    exit 1
+  fi
+
+elif [ "$MODULE" = "search_api_solr" ]; then
+  echo "Creating Search API server..."
+  SERVER_RESULT=$(drush_ev "
+    \$server = entity_create('search_api_server', array(
+      'name' => 'Pantheon Solr 9',
+      'machine_name' => 'pantheon_solr9',
+      'class' => 'search_api_solr_service',
+      'enabled' => 1,
+      'description' => 'Solr 9 server on Pantheon',
+      'options' => array(
+        'clean_ids' => 1,
+        'site_hash' => 1,
+        'scheme' => 'http',
+        'host' => 'localhost',
+        'port' => 8983,
+        'path' => '/solr',
+        'http_user' => '',
+        'http_pass' => '',
+        'excerpt' => 0,
+        'retrieve_data' => 0,
+        'highlight_data' => 0,
+        'skip_schema_check' => 0,
+        'solr_version' => '',
+        'http_method' => 'AUTO',
+        'log_query' => 0,
+        'log_response' => 0,
+        'commits_disabled' => 0,
+      ),
+    ));
+    \$server->save();
+    echo \$server->machine_name ? 'SERVER_CREATED' : 'SERVER_FAILED';
+  ") || true
+
+  if echo "$SERVER_RESULT" | grep -q "SERVER_CREATED"; then
+    echo "Search API server created."
+  else
+    echo "::error::Failed to create Search API server"
+    exit 1
+  fi
+
+  STATUS=$(drush_ev "
+    \$server = search_api_server_load('pantheon_solr9');
+    echo (\$server && \$server->ping()) ? 'SERVER_CONNECTED' : 'SERVER_DISCONNECTED';
+  ") || true
+
+  if echo "$STATUS" | grep -q "SERVER_CONNECTED"; then
+    echo "Search API server connected."
+  else
+    echo "::error::Search API server not connected"
+    exit 1
+  fi
+fi
+
+step "CUJ 6 PASSED: $MODULE configured and connected to Solr 9"

--- a/.github/scripts/solr9-cuj7-create-index.sh
+++ b/.github/scripts/solr9-cuj7-create-index.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+set -euo pipefail
+
+# CUJ 7: Create and Configure a Search Index
+# Tests that content can be indexed into Solr 9.
+# Accepts MODULE env var: apachesolr or search_api_solr
+
+SITE_ENV="${TERMINUS_SITE}.${MULTIDEV}"
+MODULE="${MODULE:?MODULE env var must be set}"
+
+# shellcheck source=.github/scripts/solr9-shared.sh
+source "$(dirname "$0")/solr9-shared.sh"
+
+step "CUJ 7: Create and Configure Search Index ($MODULE)"
+
+if [ "$MODULE" = "apachesolr" ]; then
+
+  step "Step 1: Configure indexing and mark content"
+  drush_ev "
+    \$env_id = apachesolr_default_environment();
+    module_load_include('inc', 'apachesolr', 'apachesolr.index');
+    apachesolr_index_set_bundles(\$env_id, 'node', array('article', 'page'));
+  " || true
+  echo "Configured article and page bundles for indexing."
+  terminus drush "$SITE_ENV" -- solr-mark-all
+
+  step "Step 2: Index content"
+  terminus drush "$SITE_ENV" -- solr-index
+
+  step "Step 3: Verify index via search"
+  VERIFY=$(drush_ev "
+    \$results = node_search_execute('Solr');
+    echo 'VERIFY_COUNT:' . count(\$results) . ' ';
+  ") || true
+
+  if echo "$VERIFY" | grep -qE "VERIFY_COUNT:[1-9]"; then
+    COUNT=$(echo "$VERIFY" | grep -o 'VERIFY_COUNT:[0-9]*' | head -1 | cut -d: -f2)
+    echo "Search verification: $COUNT results for 'Solr'."
+  else
+    echo "::error::Index verification failed: search returned 0 results after indexing"
+    exit 1
+  fi
+
+elif [ "$MODULE" = "search_api_solr" ]; then
+
+  step "Step 1: Create Search API index"
+  INDEX_RESULT=$(drush_ev "
+    \$index = entity_create('search_api_index', array(
+      'name' => 'Site Content',
+      'machine_name' => 'site_content',
+      'server' => 'pantheon_solr9',
+      'item_type' => 'node',
+      'enabled' => 1,
+      'options' => array(
+        'index_directly' => 1,
+        'fields' => array(
+          'title' => array('type' => 'text'),
+          'body:value' => array('type' => 'text'),
+          'type' => array('type' => 'string'),
+          'status' => array('type' => 'boolean'),
+        ),
+      ),
+    ));
+    \$index->save();
+    echo \$index->machine_name ? 'INDEX_CREATED' : 'INDEX_FAILED';
+  ") || true
+
+  if echo "$INDEX_RESULT" | grep -q "INDEX_CREATED"; then
+    echo "Search API index created."
+  else
+    echo "::error::Failed to create Search API index"
+    exit 1
+  fi
+
+  step "Step 2: Index content"
+  terminus drush "$SITE_ENV" -- search-api-index site_content
+
+  step "Step 3: Verify index status"
+  STATUS=$(terminus drush "$SITE_ENV" -- search-api-status site_content 2>&1)
+  echo "$STATUS"
+
+  if echo "$STATUS" | grep -q "100%"; then
+    echo "Index is 100% complete."
+  else
+    if echo "$STATUS" | grep -qE "Indexed.*[1-9]"; then
+      echo "Warning: Index not 100% but items were indexed."
+    else
+      echo "::error::No items indexed"
+      exit 1
+    fi
+  fi
+
+else
+  echo "::error::Unknown module: $MODULE"
+  exit 1
+fi
+
+step "CUJ 7 PASSED: $MODULE index created and content indexed"

--- a/.github/scripts/solr9-cuj8-validate-search.sh
+++ b/.github/scripts/solr9-cuj8-validate-search.sh
@@ -1,0 +1,115 @@
+#!/bin/bash
+set -euo pipefail
+
+# CUJ 8: Validate That Solr 9 is Serving Search Results
+# Tests that indexed content is searchable and results are correct.
+# Accepts MODULE env var: apachesolr or search_api_solr
+
+SITE_ENV="${TERMINUS_SITE}.${MULTIDEV}"
+MODULE="${MODULE:?MODULE env var must be set}"
+
+# shellcheck source=.github/scripts/solr9-shared.sh
+source "$(dirname "$0")/solr9-shared.sh"
+
+step "CUJ 8: Validate Search Results ($MODULE)"
+
+step "Step 1: Search for known term"
+
+if [ "$MODULE" = "apachesolr" ]; then
+  SEARCH_RESULT=$(drush_ev "
+    \$results = node_search_execute('Solr');
+    echo 'FOUND:' . count(\$results) . ' ';
+  ") || true
+elif [ "$MODULE" = "search_api_solr" ]; then
+  SEARCH_RESULT=$(drush_ev "
+    \$index = search_api_index_load('site_content');
+    \$query = new SearchApiQuery(\$index);
+    \$query->keys('Solr');
+    \$query->range(0, 10);
+    \$results = \$query->execute();
+    echo 'FOUND:' . \$results['result count'] . ' ';
+  ") || true
+fi
+
+if echo "$SEARCH_RESULT" | grep -qE "FOUND:[1-9]"; then
+  COUNT=$(echo "$SEARCH_RESULT" | grep -o 'FOUND:[0-9]*' | head -1 | cut -d: -f2)
+  echo "Search for 'Solr' returned $COUNT results."
+else
+  echo "::error::Search for 'Solr' returned 0 results (expected > 0)"
+  exit 1
+fi
+
+step "Step 2: Search for non-existent term"
+
+if [ "$MODULE" = "apachesolr" ]; then
+  EMPTY_RESULT=$(drush_ev "
+    \$results = node_search_execute('xyznonexistent99');
+    echo 'FOUND:' . count(\$results) . ' ';
+  ") || true
+elif [ "$MODULE" = "search_api_solr" ]; then
+  EMPTY_RESULT=$(drush_ev "
+    \$index = search_api_index_load('site_content');
+    \$query = new SearchApiQuery(\$index);
+    \$query->keys('xyznonexistent99');
+    \$query->range(0, 1);
+    \$results = \$query->execute();
+    echo 'FOUND:' . \$results['result count'] . ' ';
+  ") || true
+fi
+
+if echo "$EMPTY_RESULT" | grep -q "FOUND:0"; then
+  echo "Search for non-existent term correctly returned 0 results."
+else
+  echo "::warning::Expected 0 results for non-existent term"
+fi
+
+step "Step 3: Check watchdog for Solr errors"
+
+if [ "$MODULE" = "apachesolr" ]; then
+  WD_TYPE="Apache Solr"
+else
+  WD_TYPE="search_api_solr"
+fi
+
+ERRORS=$(terminus drush "$SITE_ENV" -- watchdog-show "--type=$WD_TYPE" --count=10 2>&1) || true
+
+if echo "$ERRORS" | grep -qiE "Unrecognized message type|No log messages"; then
+  echo "No Solr log entries in watchdog (type '$WD_TYPE' not present)."
+else
+  REAL_ERRORS=$(echo "$ERRORS" | grep -i "error" | grep -vi "Unrecognized message type\|Exit:\|Command:" || true)
+  if [ -n "$REAL_ERRORS" ]; then
+    echo "::warning::Solr errors found in watchdog:"
+    echo "$REAL_ERRORS"
+  else
+    echo "No Solr errors in watchdog."
+  fi
+fi
+
+step "Step 4: Verify Solr ping"
+
+PING=$(drush_ev "
+  \$host = PANTHEON_APACHESOLR_HOST;
+  \$path = getenv('PANTHEON_INDEX_PATH') . getenv('PANTHEON_INDEX_CORE') . '/admin/ping';
+  if ('$MODULE' === 'search_api_solr') {
+    \$path .= '?q=id:1';
+  }
+  \$url = 'https://' . \$host . '/' . \$path;
+  list(\$ch, \$opts) = pantheon_apachesolr_curl_setup(\$url, PANTHEON_APACHESOLR_PORT);
+  \$opts = pantheon_apachesolr_curlopts(\$opts);
+  \$opts[CURLOPT_CONNECTTIMEOUT] = 5;
+  \$opts[CURLOPT_RETURNTRANSFER] = 1;
+  curl_setopt_array(\$ch, \$opts);
+  \$response = curl_exec(\$ch);
+  \$info = curl_getinfo(\$ch);
+  curl_close(\$ch);
+  echo in_array(\$info['http_code'], array(200, 201, 202, 204)) ? 'PING_OK' : 'PING_FAILED';
+") || true
+
+if echo "$PING" | grep -q "PING_OK"; then
+  echo "Solr ping healthy."
+else
+  echo "::error::Solr ping failed"
+  exit 1
+fi
+
+step "CUJ 8 PASSED: $MODULE search results validated"

--- a/.github/scripts/solr9-setup-multidev.sh
+++ b/.github/scripts/solr9-setup-multidev.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+set -euo pipefail
+
+# Create a Pantheon multidev with Solr 9 configured for D7 CUJ testing.
+# Clones the fixture site's dev environment, sets search version to 9,
+# pushes the current branch code, and installs the target search module.
+
+MULTIDEV="$1"
+TERMINUS_SITE="$2"
+MODULE="${MODULE:?MODULE env var must be set (apachesolr or search_api_solr)}"
+
+# shellcheck source=.github/scripts/solr9-shared.sh
+source "$(dirname "$0")/solr9-shared.sh"
+
+step "Phase 1: Create multidev and configure Solr 9"
+
+# Delete existing multidev if present (from a previous failed run)
+if terminus multidev:list "$TERMINUS_SITE" --format=list 2>/dev/null | grep -q "^$MULTIDEV$"; then
+  step "Deleting existing multidev: $MULTIDEV"
+  terminus multidev:delete "$TERMINUS_SITE.$MULTIDEV" --delete-branch --yes
+fi
+
+step "Creating multidev $MULTIDEV from dev"
+terminus multidev:create "$TERMINUS_SITE.dev" "$MULTIDEV"
+
+step "Cloning Pantheon site repo"
+GIT_URL=$(terminus connection:info "$TERMINUS_SITE.$MULTIDEV" --field=git_url)
+GIT_SSH_COMMAND="ssh -o StrictHostKeyChecking=no" git clone "$GIT_URL" pantheon-site
+
+cd pantheon-site
+git checkout "$MULTIDEV"
+
+step "Copying pantheon_apachesolr module"
+rm -rf modules/pantheon/pantheon_apachesolr
+cp -r "$GITHUB_WORKSPACE/modules/pantheon/pantheon_apachesolr" modules/pantheon/pantheon_apachesolr
+
+step "Pushing code to Pantheon"
+git add -A
+git commit -m "CI: Solr 9 CUJ test - $MODULE (run $GITHUB_RUN_NUMBER)" || echo "No changes to commit"
+git push origin "$MULTIDEV" || echo "Nothing to push"
+
+cd ..
+
+step "Waiting for Pantheon workflow to complete"
+terminus workflow:wait "$TERMINUS_SITE.$MULTIDEV" --max=600
+
+SITE_ENV="$TERMINUS_SITE.$MULTIDEV"
+
+step "Verifying environment"
+terminus env:info "$SITE_ENV"
+
+step "Checking Solr version"
+SOLR_VER=$(terminus drush "$SITE_ENV" -- ev "echo \$_ENV['search_version'] ?? 'not_set';" 2>/dev/null | tr -d '[:space:]')
+echo "Solr version: $SOLR_VER"
+if [ "$SOLR_VER" != "9" ]; then
+  echo "::error::Expected Solr version 9, got: $SOLR_VER"
+  exit 1
+fi
+
+step "Enabling base modules (search, update, tag1_d7es, pantheon_apachesolr)"
+terminus drush "$SITE_ENV" -- en search update tag1_d7es pantheon_apachesolr -y
+
+step "Switching to SFTP mode"
+terminus connection:set "$SITE_ENV" sftp
+
+step "Downloading $MODULE via drush dl (Tag1 D7ES)"
+
+if [ "$MODULE" = "apachesolr" ]; then
+  terminus drush "$SITE_ENV" -- dl apachesolr-7.x-1.15 -y
+
+  step "Enabling apachesolr and apachesolr_search"
+  terminus drush "$SITE_ENV" -- en apachesolr apachesolr_search -y
+
+elif [ "$MODULE" = "search_api_solr" ]; then
+  terminus drush "$SITE_ENV" -- dl entity search_api -y
+  terminus drush "$SITE_ENV" -- dl search_api_solr-7.x-1.19 -y
+
+  step "Enabling entity, search_api, search_api_solr"
+  terminus drush "$SITE_ENV" -- en entity search_api search_api_solr -y
+
+else
+  echo "::error::Unknown module: $MODULE"
+  exit 1
+fi
+
+step "Committing SFTP changes and switching to git mode"
+terminus env:commit "$SITE_ENV" --message="CI: Install $MODULE module" --force
+terminus connection:set "$SITE_ENV" git
+
+step "Verifying modules are enabled"
+terminus drush "$SITE_ENV" -- pm-list --status=enabled --type=module | grep -iE "$MODULE|pantheon_apachesolr"
+
+step "Phase 1 complete: Multidev $MULTIDEV ready with Solr 9 + $MODULE"

--- a/.github/scripts/solr9-shared.sh
+++ b/.github/scripts/solr9-shared.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# Shared helpers for solr9 CUJ scripts. Sourced, not executed.
+# No set flags here: they would leak into the sourcing script's shell.
+
+step() { echo ""; echo ">>>>>>>>>> $1 <<<<<<<<<<"; echo ""; }
+
+drush_ev() {
+  terminus drush "$SITE_ENV" -- ev "$@" 2>&1
+}

--- a/.github/workflows/solr9-cujs.yml
+++ b/.github/workflows/solr9-cujs.yml
@@ -1,0 +1,109 @@
+name: Solr 9 CUJ Tests
+
+on:
+  push:
+    paths:
+      - 'modules/pantheon/pantheon_apachesolr/**'
+      - '.github/workflows/solr9-cujs.yml'
+      - '.github/scripts/solr9-*'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: 'solr9-cujs-${{ github.head_ref || github.ref }}'
+  cancel-in-progress: true
+
+jobs:
+  solr9-cujs:
+    name: Solr 9 CUJs (${{ matrix.module }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        module: [apachesolr, search_api_solr]
+    env:
+      TERMINUS_SITE: ${{ vars.PANTHEON_SITE_D7 }}
+      TERMINUS_TOKEN: ${{ secrets.TERMINUS_TOKEN }}
+      PANTHEON_SSH_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+      MODULE: ${{ matrix.module }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@8358ee0e2e8afe63c2fb8253d1d52085811ab1e5 # v2
+        with:
+          php-version: '8.2'
+          tools: composer:v2
+
+      - name: Install Terminus
+        uses: pantheon-systems/terminus-github-actions@409451ede17f75acac08f42edc823fee6c435057 # v1.2.8
+        with:
+          pantheon-machine-token: ${{ env.TERMINUS_TOKEN }}
+
+      - name: Verify Terminus auth
+        run: terminus auth:whoami
+
+      - name: Setup SSH
+        uses: webfactory/ssh-agent@a6f90b1f127823b31d4d4a8d96047790581349bd # v0.9.1
+        with:
+          ssh-private-key: ${{ env.PANTHEON_SSH_KEY }}
+
+      - name: Configure SSH
+        run: |
+          mkdir -p ~/.ssh
+          printf "Host *\n  StrictHostKeyChecking no\n  UserKnownHostsFile=/dev/null\n" > ~/.ssh/config
+
+      - name: Setup Git
+        run: |
+          git config --global user.email "ci@pantheon.io"
+          git config --global user.name "Github Actions"
+          git config --global --add safe.directory '*'
+
+      - name: Set multidev name
+        run: |
+          if [ "$MODULE" = "apachesolr" ]; then
+            MODULE_SHORT="apch"
+          else
+            MODULE_SHORT="sapi"
+          fi
+          MULTIDEV_NAME="s9${MODULE_SHORT}${GITHUB_RUN_NUMBER}"
+          MULTIDEV="${MULTIDEV_NAME:0:11}"
+          echo "MULTIDEV=$MULTIDEV" >> "$GITHUB_ENV"
+          echo "MULTIDEV_PREFIX=s9${MODULE_SHORT}" >> "$GITHUB_ENV"
+          echo "Using multidev: $MULTIDEV"
+
+      - name: Create multidev and configure Solr 9
+        run: bash .github/scripts/solr9-setup-multidev.sh "$MULTIDEV" "$TERMINUS_SITE"
+
+      - name: CUJ 6 - Configure Solr Server
+        run: bash .github/scripts/solr9-cuj6-configure-server.sh
+
+      - name: CUJ 7 - Create and Configure Search Index
+        run: bash .github/scripts/solr9-cuj7-create-index.sh
+
+      - name: CUJ 8 - Validate Search Results
+        run: bash .github/scripts/solr9-cuj8-validate-search.sh
+
+      - name: Delete multidev on success
+        if: success()
+        run: terminus multidev:delete "$TERMINUS_SITE.$MULTIDEV" --delete-branch --yes || true
+
+      - name: Show multidev URL on failure
+        if: failure()
+        run: 'echo "Multidev URL for investigation: https://${MULTIDEV}-${TERMINUS_SITE}.pantheonsite.io"'
+
+      - name: Cleanup stale CI multidevs
+        if: always()
+        run: |
+          MULTIDEVS=$(terminus multidev:list "$TERMINUS_SITE" --format=list 2>/dev/null || echo "")
+          for env in $MULTIDEVS; do
+            if [[ "$env" == ${MULTIDEV_PREFIX}* && "$env" != "$MULTIDEV" ]]; then
+              echo "Deleting stale multidev: $env"
+              terminus multidev:delete "$TERMINUS_SITE.$env" --delete-branch --yes || true
+            fi
+          done

--- a/modules/pantheon/pantheon_apachesolr/Pantheon_Apache_Solr_Service.php
+++ b/modules/pantheon/pantheon_apachesolr/Pantheon_Apache_Solr_Service.php
@@ -223,18 +223,33 @@ class PantheonApacheSolrService implements DrupalApacheSolrServiceInterface{
     $data = $this->getLuke();
     // Only try to get stats if we have connected to the index.
     if (empty($this->stats) && isset($data->index->numDocs)) {
-      $url = $this->_constructUrl(self::STATS_SERVLET);
+      if (pantheon_apachesolr_get_search_version() == 9) {
+        $url = $this->_constructUrl(self::SYSTEM_SERVLET, array('wt' => 'json'));
+      }
+      else {
+        $url = $this->_constructUrl(self::STATS_SERVLET);
+      }
       if ($this->env_id) {
         $this->stats_cid = $this->env_id . ":stats:" . drupal_hash_base64($url);
         $cache = cache_get($this->stats_cid, 'cache_apachesolr');
         if (isset($cache->data)) {
-          $this->stats = simplexml_load_string($cache->data);
+          if (pantheon_apachesolr_get_search_version() == 9) {
+            $this->stats = json_decode($cache->data);
+          }
+          else {
+            $this->stats = simplexml_load_string($cache->data);
+          }
         }
       }
       // Second pass to populate the cache if necessary.
       if (empty($this->stats)) {
         $response = $this->_sendRawGet($url);
-        $this->stats = simplexml_load_string($response->data);
+        if (pantheon_apachesolr_get_search_version() == 9) {
+          $this->stats = json_decode($response->data);
+        }
+        else {
+          $this->stats = simplexml_load_string($response->data);
+        }
         if ($this->env_id) {
           cache_set($this->stats_cid, $response->data, 'cache_apachesolr');
         }
@@ -272,24 +287,30 @@ class PantheonApacheSolrService implements DrupalApacheSolrServiceInterface{
     );
 
     if (!empty($stats)) {
-      $docs_pending_xpath = $stats->xpath('//stat[@name="docsPending"]');
-      $summary['@pending_docs'] = (int) trim($docs_pending_xpath[0]);
-      $max_time_xpath = $stats->xpath('//stat[@name="autocommit maxTime"]');
-      $max_time = (int) trim(current($max_time_xpath));
-      // Convert to seconds.
-      $summary['@autocommit_time_seconds'] = $max_time / 1000;
-      $summary['@autocommit_time'] = format_interval($max_time / 1000);
-      $deletes_id_xpath = $stats->xpath('//stat[@name="deletesById"]');
-      $summary['@deletes_by_id'] = (int) trim($deletes_id_xpath[0]);
-      $deletes_query_xpath = $stats->xpath('//stat[@name="deletesByQuery"]');
-      $summary['@deletes_by_query'] = (int) trim($deletes_query_xpath[0]);
-      $summary['@deletes_total'] = $summary['@deletes_by_id'] + $summary['@deletes_by_query'];
-      $schema = $stats->xpath('/solr/schema[1]');
-      $summary['@schema_version'] = trim($schema[0]);;
-      $core = $stats->xpath('/solr/core[1]');
-      $summary['@core_name'] = trim($core[0]);
-      $size_xpath = $stats->xpath('//stat[@name="indexSize"]');
-      $summary['@index_size'] = trim(current($size_xpath));
+      if (pantheon_apachesolr_get_search_version() == 9) {
+        $summary['@schema_version'] = isset($stats->core->schema) ? $stats->core->schema : '';
+        $summary['@core_name'] = isset($stats->core->directory->instance) ? str_replace('/var/solr/data/', '', $stats->core->directory->instance) : '';
+      }
+      else {
+        $docs_pending_xpath = $stats->xpath('//stat[@name="docsPending"]');
+        $summary['@pending_docs'] = (int) trim($docs_pending_xpath[0]);
+        $max_time_xpath = $stats->xpath('//stat[@name="autocommit maxTime"]');
+        $max_time = (int) trim(current($max_time_xpath));
+        // Convert to seconds.
+        $summary['@autocommit_time_seconds'] = $max_time / 1000;
+        $summary['@autocommit_time'] = format_interval($max_time / 1000);
+        $deletes_id_xpath = $stats->xpath('//stat[@name="deletesById"]');
+        $summary['@deletes_by_id'] = (int) trim($deletes_id_xpath[0]);
+        $deletes_query_xpath = $stats->xpath('//stat[@name="deletesByQuery"]');
+        $summary['@deletes_by_query'] = (int) trim($deletes_query_xpath[0]);
+        $summary['@deletes_total'] = $summary['@deletes_by_id'] + $summary['@deletes_by_query'];
+        $schema = $stats->xpath('/solr/schema[1]');
+        $summary['@schema_version'] = trim($schema[0]);;
+        $core = $stats->xpath('/solr/core[1]');
+        $summary['@core_name'] = trim($core[0]);
+        $size_xpath = $stats->xpath('//stat[@name="indexSize"]');
+        $summary['@index_size'] = trim(current($size_xpath));
+      }
     }
 
     return $summary;
@@ -335,9 +356,16 @@ class PantheonApacheSolrService implements DrupalApacheSolrServiceInterface{
     // Pantheon-specific URL settings.
     // Note: we don't pass a port at this time, because the parent This data
     // is added later in the _makeHttpRequest() method.
-    $host = variable_get('pantheon_index_host', 'index.'. variable_get('pantheon_tier', 'live') .'.getpantheon.com');
-    $path = 'sites/self/environments/'. variable_get('pantheon_environment', 'dev') .'/index';
-    $url = 'https://'. $host .'/'. $path;
+    if (pantheon_apachesolr_get_search_version() == 9) {
+      $host = getenv('PANTHEON_INDEX_HOST');
+      $path = getenv('PANTHEON_INDEX_PATH') . getenv('PANTHEON_INDEX_CORE');
+      $url = getenv('PANTHEON_INDEX_SCHEME') . '://' . $host . '/' . $path;
+    }
+    else {
+      $host = variable_get('pantheon_index_host', 'index.'. variable_get('pantheon_tier', 'live') .'.getpantheon.com');
+      $path = 'sites/self/environments/'. variable_get('pantheon_environment', 'dev') .'/index';
+      $url = 'https://'. $host .'/'. $path;
+    }
 
 
     $this->setUrl($url);
@@ -448,7 +476,12 @@ class PantheonApacheSolrService implements DrupalApacheSolrServiceInterface{
     // Hacking starts here.
     // $result = drupal_http_request($url, $headers, $method, $content);
     static $ch;
-    $port = variable_get('pantheon_index_port', 449);
+    if (pantheon_apachesolr_get_search_version() == 9) {
+      $port = intval(getenv('PANTHEON_INDEX_PORT'));
+    }
+    else {
+      $port = variable_get('pantheon_index_port', 449);
+    }
 
     if (!isset($ch)) {
       // The parent PHPSolrClient library assumes http
@@ -729,11 +762,16 @@ class PantheonApacheSolrService implements DrupalApacheSolrServiceInterface{
    * @throws Exception If an error occurs during the service call
    */
   public function commit($optimize = true, $waitFlush = true, $waitSearcher = true, $timeout = 3600) {
-    $optimizeValue = $optimize ? 'true' : 'false';
-    $flushValue = $waitFlush ? 'true' : 'false';
     $searcherValue = $waitSearcher ? 'true' : 'false';
 
-    $rawPost = '<commit optimize="' . $optimizeValue . '" waitFlush="' . $flushValue . '" waitSearcher="' . $searcherValue . '" />';
+    if (pantheon_apachesolr_get_search_version() == 9) {
+      $rawPost = '<commit waitSearcher="' . $searcherValue . '" />';
+    }
+    else {
+      $optimizeValue = $optimize ? 'true' : 'false';
+      $flushValue = $waitFlush ? 'true' : 'false';
+      $rawPost = '<commit optimize="' . $optimizeValue . '" waitFlush="' . $flushValue . '" waitSearcher="' . $searcherValue . '" />';
+    }
 
     $response = $this->update($rawPost, $timeout);
     $this->_clearCache();

--- a/modules/pantheon/pantheon_apachesolr/Pantheon_Search_Api_Solr_Service.php
+++ b/modules/pantheon/pantheon_apachesolr/Pantheon_Search_Api_Solr_Service.php
@@ -3,21 +3,30 @@
 /**
  * Current Supported Class for RC4+
  */
+#[\AllowDynamicProperties]
 class PantheonApachesolrSearchApiSolrConnection extends SearchApiSolrConnection {
 
-  /**
-   * @var string
-   */
+  protected $base_url;
+  protected $http_auth;
   protected $method;
+  protected $options;
 
   function __construct(array $options) {
 
-    // Adding in custom settings for Pantheon
-    $options['scheme'] = 'https';
-    $options['host'] = variable_get('pantheon_index_host', 'index.'. variable_get('pantheon_tier', 'live') .'.getpantheon.com');
-    $options['path'] = 'sites/self/environments/' . variable_get('pantheon_environment', 'dev') . '/index';
-    $options['port'] = variable_get('pantheon_index_port', 449);
-    
+    // Adding in custom settings for Pantheon.
+    if (pantheon_apachesolr_get_search_version() == 9) {
+      $options['scheme'] = getenv('PANTHEON_INDEX_SCHEME');
+      $options['host'] = getenv('PANTHEON_INDEX_HOST');
+      $options['path'] = getenv('PANTHEON_INDEX_PATH') . getenv('PANTHEON_INDEX_CORE');
+      $options['port'] = intval(getenv('PANTHEON_INDEX_PORT'));
+    }
+    else {
+      $options['scheme'] = 'https';
+      $options['host'] = variable_get('pantheon_index_host', 'index.'. variable_get('pantheon_tier', 'live') .'.getpantheon.com');
+      $options['path'] = 'sites/self/environments/' . variable_get('pantheon_environment', 'dev') . '/index';
+      $options['port'] = variable_get('pantheon_index_port', 449);
+    }
+
     // pantheon_curl_setup will determine whether binding.pem needed and return
     // path in options if so.
     list($ch, $opts) = pantheon_apachesolr_curl_setup("", $options['port']);
@@ -35,12 +44,12 @@ class PantheonApachesolrSearchApiSolrConnection extends SearchApiSolrConnection 
             $sslContext['verify_peer_name'] = (bool) $opts[CURLOPT_SSL_VERIFYHOST];
         }
     }
-    
+
     if ($sslContext) {
         $this->setStreamContext(stream_context_create(array('ssl' => $sslContext)));
     }
 
-    // Adding in general settings for Search API
+    // Adding in general settings for Search API.
     $options += array(
       'scheme' => 'http',
       'host' => 'localhost',
@@ -118,5 +127,56 @@ class PantheonApachesolrSearchApiSolrConnection extends SearchApiSolrConnection 
 
 class PantheonApachesolrSearchApiSolrService extends SearchApiSolrService {
   protected $connection_class = 'PantheonApachesolrSearchApiSolrConnection';
-}
 
+  /**
+   * {@inheritdoc}
+   */
+  public function getServerLink() {
+    if (pantheon_apachesolr_get_search_version() == 9) {
+      $url = getenv('PANTHEON_INDEX_SCHEME') . '://' . getenv('PANTHEON_INDEX_HOST') . ':' . intval(getenv('PANTHEON_INDEX_PORT')) . '/' . getenv('PANTHEON_INDEX_PATH') . getenv('PANTHEON_INDEX_CORE');
+    }
+    else {
+      if (!$this->options) {
+        return '';
+      }
+      $host = $this->options['host'];
+      if ($host == 'localhost' && !empty($_SERVER['SERVER_NAME'])) {
+        $host = $_SERVER['SERVER_NAME'];
+      }
+      $url = $this->options['scheme'] . '://' . $host . ':' . $this->options['port'] . $this->options['path'];
+    }
+    return l($url, $url);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function ping() {
+    if (pantheon_apachesolr_get_search_version() == 9) {
+      $host = PANTHEON_APACHESOLR_HOST;
+      $path = getenv('PANTHEON_INDEX_PATH') . getenv('PANTHEON_INDEX_CORE') . '/admin/ping';
+      $pantheon_apachesolr_schema = variable_get('pantheon_apachesolr_schema');
+
+      if (strpos($pantheon_apachesolr_schema, 'search_api_solr') !== FALSE) {
+        $path .= '?q=id:1';
+      }
+
+      $url = 'https://'. $host . '/' . $path;
+
+      list($ch, $opts) = pantheon_apachesolr_curl_setup($url, PANTHEON_APACHESOLR_PORT);
+      $opts[CURLOPT_CONNECTTIMEOUT] = 5;
+      $opts[CURLOPT_RETURNTRANSFER] = 1;
+
+      curl_setopt_array($ch, $opts);
+      $response = curl_exec($ch);
+      $info = curl_getinfo($ch);
+      curl_close($ch);
+      return ($info['http_code'] == 200);
+    }
+    else {
+      $this->connect(FALSE);
+      return $this->solr->ping();
+    }
+  }
+
+}

--- a/modules/pantheon/pantheon_apachesolr/pantheon_apachesolr.info
+++ b/modules/pantheon/pantheon_apachesolr/pantheon_apachesolr.info
@@ -1,7 +1,7 @@
 name = Pantheon Apache Solr
 description = Exposes Pantheon's ApacheSolr Service
 package = Pantheon
-version = "7.x-1.1.1"
+version = "7.x-1.2.0"
 files[] = Pantheon_Apache_Solr_Service.php
 files[] = Pantheon_Search_Api_Solr_Service.php
 configure = admin/config/search/pantheon

--- a/modules/pantheon/pantheon_apachesolr/pantheon_apachesolr.module
+++ b/modules/pantheon/pantheon_apachesolr/pantheon_apachesolr.module
@@ -5,8 +5,16 @@
  *
  * Facilitates and debugs communication with Pantheon's Apache Solr service.
  */
-define('PANTHEON_APACHESOLR_PORT', variable_get('pantheon_index_port', 449));
-define('PANTHEON_APACHESOLR_HOST', variable_get('pantheon_index_host', 'index.'. variable_get('pantheon_tier', 'live') .'.getpantheon.com'));
+if (pantheon_apachesolr_get_search_version() == 9) {
+  $pantheon_apachesolr_host = getenv('PANTHEON_INDEX_HOST');
+  $pantheon_apachesolr_port = intval(getenv('PANTHEON_INDEX_PORT'));
+}
+else {
+  $pantheon_apachesolr_host = variable_get('pantheon_index_host', 'index.'. variable_get('pantheon_tier', 'live') .'.getpantheon.com');
+  $pantheon_apachesolr_port = variable_get('pantheon_index_port', 449);
+}
+define('PANTHEON_APACHESOLR_PORT', $pantheon_apachesolr_port);
+define('PANTHEON_APACHESOLR_HOST', $pantheon_apachesolr_host);
 
 /**
  * Implements hook_help().
@@ -172,6 +180,14 @@ function pantheon_apachesolr_platform_detected() {
 }
 
 /**
+ * Return Pantheon Search Version if detected.
+ * @return string|null
+ */
+function pantheon_apachesolr_get_search_version() {
+  return isset($_ENV['search_version']) ? $_ENV['search_version'] : NULL;
+}
+
+/**
  * Display an error message if not running on the Pantheon platform.
  */
 function pantheon_apachesolr_display_error_if_disabled() {
@@ -183,6 +199,8 @@ function pantheon_apachesolr_display_error_if_disabled() {
 }
 
 /**
+ * Posts the schema files to the SOLR server.
+ *
  * @param string $schema
  *   Path to local schema XML
  *
@@ -209,35 +227,76 @@ function pantheon_apachesolr_post_schema_exec($schema) {
     return NULL;
   }
 
-  $host = PANTHEON_APACHESOLR_HOST;
-  $path = 'sites/self/environments/'. variable_get('pantheon_environment', 'dev') .'/index';
+  if (pantheon_apachesolr_get_search_version() == 9) {
+    $host = PANTHEON_APACHESOLR_HOST;
+    $path = getenv('PANTHEON_INDEX_PATH') . getenv('PANTHEON_INDEX_SCHEMA');
+    $url = 'https://'. $host .'/'. $path;
 
-  $url = 'https://'. $host .'/'. $path;
+    $schema_directory = dirname($schema);
+    $schema_files = scandir($schema_directory);
+    $files = array('files' => array());
+    foreach ($schema_files as $schema_file) {
+      if (!in_array($schema_file, array('.', '..'))) {
+        $files['files'][] = array(
+          'filename' => $schema_file,
+          'content' => base64_encode(file_get_contents($schema_directory . '/' . $schema_file)),
+        );
+      }
+    }
 
-  list($ch, $opts) = pantheon_apachesolr_curl_setup($url, PANTHEON_APACHESOLR_PORT);
-  
-  $file = fopen($schema, 'r');
-  // set (or override) remaining headers
-  $opts = array_replace($opts, array(
-    CURLOPT_RETURNTRANSFER => 1,
-    CURLOPT_HTTPHEADER => array('Content-type:text/xml; charset=utf-8'),
-    CURLOPT_PUT => TRUE,
-    CURLOPT_BINARYTRANSFER => 1,
-    CURLOPT_INFILE => $file,
-    CURLOPT_INFILESIZE => filesize($schema),
-  ));
-  
-  curl_setopt_array($ch, $opts);
-  $response = curl_exec($ch);
-  $info = curl_getinfo($ch);
-  $success_codes = array(
-    '200',
-    '201',
-    '202',
-    '204'
-  );
-  $success = (in_array($info['http_code'], $success_codes));
-  fclose($file);
+    list($ch, $opts) = pantheon_apachesolr_curl_setup($url, PANTHEON_APACHESOLR_PORT);
+    $opts = array_replace($opts, array(
+      CURLOPT_RETURNTRANSFER => 1,
+      CURLOPT_HTTPHEADER => array('ACCEPT:application/json', 'Content-type:application/json'),
+      CURLOPT_POST => TRUE,
+      CURLOPT_POSTFIELDS => json_encode($files),
+    ));
+
+    curl_setopt_array($ch, $opts);
+    $response = curl_exec($ch);
+    $info = curl_getinfo($ch);
+    $success_codes = array(
+      '200',
+      '201',
+      '202',
+      '204'
+    );
+    $success = (in_array($info['http_code'], $success_codes));
+
+    if ($success) {
+      pantheon_apachesolr_reload_server_exec();
+    }
+  }
+  else {
+    $host = PANTHEON_APACHESOLR_HOST;
+    $path = 'sites/self/environments/'. variable_get('pantheon_environment', 'dev') .'/index';
+
+    $url = 'https://'. $host .'/'. $path;
+
+    list($ch, $opts) = pantheon_apachesolr_curl_setup($url, PANTHEON_APACHESOLR_PORT);
+
+    $file = fopen($schema, 'r');
+    $opts = array_replace($opts, array(
+      CURLOPT_RETURNTRANSFER => 1,
+      CURLOPT_HTTPHEADER => array('Content-type:text/xml; charset=utf-8'),
+      CURLOPT_PUT => TRUE,
+      CURLOPT_BINARYTRANSFER => 1,
+      CURLOPT_INFILE => $file,
+      CURLOPT_INFILESIZE => filesize($schema),
+    ));
+
+    curl_setopt_array($ch, $opts);
+    $response = curl_exec($ch);
+    $info = curl_getinfo($ch);
+    $success_codes = array(
+      '200',
+      '201',
+      '202',
+      '204'
+    );
+    $success = (in_array($info['http_code'], $success_codes));
+    fclose($file);
+  }
   if (!$success) {
     watchdog('pantheon_apachesolr', 'Error !error posting !schema to !url', array(
       '!error' => curl_error($ch),
@@ -250,6 +309,40 @@ function pantheon_apachesolr_post_schema_exec($schema) {
   }
 
   return $success;
+}
+
+/**
+ * Reloads the SOLR server.
+ */
+function pantheon_apachesolr_reload_server_exec() {
+  if (!pantheon_apachesolr_platform_detected()) {
+    return;
+  }
+
+  $host = PANTHEON_APACHESOLR_HOST;
+  $path = getenv('PANTHEON_INDEX_PATH') . getenv('PANTHEON_INDEX_RELOAD_PATH');
+  $url = 'https://'. $host .'/'. $path;
+
+  list($ch, $opts) = pantheon_apachesolr_curl_setup($url, PANTHEON_APACHESOLR_PORT);
+  $opts = array_replace($opts, array(
+    CURLOPT_RETURNTRANSFER => 1,
+    CURLOPT_HTTPHEADER => array('ACCEPT:application/json', 'Content-type:application/json'),
+    CURLOPT_POST => TRUE,
+  ));
+
+  curl_setopt_array($ch, $opts);
+  $response = curl_exec($ch);
+  $info = curl_getinfo($ch);
+  $success_codes = array(
+    '200',
+    '201',
+    '202',
+    '204'
+  );
+  $success = (in_array($info['http_code'], $success_codes));
+  if (!$success) {
+    watchdog('pantheon_apachesolr', 'Unable to reload Pantheon SOLR server.', array(), WATCHDOG_ERROR);
+  }
 }
 
 /**
@@ -321,8 +414,14 @@ function pantheon_apachesolr_query($form, &$form_state) {
     );
   }
 
+
   $host = PANTHEON_APACHESOLR_HOST;
-  $path = 'sites/self/environments/'. variable_get('pantheon_environment', 'dev') .'/index';
+  if (pantheon_apachesolr_get_search_version() == 9) {
+    $path = getenv('PANTHEON_INDEX_PATH') . getenv('PANTHEON_INDEX_CORE');
+  }
+  else {
+    $path = 'sites/self/environments/'. variable_get('pantheon_environment', 'dev') .'/index';
+  }
   $url = 'https://'. $host .'/'. $path;
 
   $form['query_string'] = array(
@@ -355,7 +454,12 @@ function pantheon_apachesolr_query_submit($form, &$form_state) {
   $form_state['rebuild'] = TRUE;
 
   $host = PANTHEON_APACHESOLR_HOST;
-  $path = 'sites/self/environments/'. variable_get('pantheon_environment', 'dev') .'/index';
+  if (pantheon_apachesolr_get_search_version() == 9) {
+    $path = getenv('PANTHEON_INDEX_PATH') . getenv('PANTHEON_INDEX_CORE');
+  }
+  else {
+    $path = 'sites/self/environments/'. variable_get('pantheon_environment', 'dev') .'/index';
+  }
   $url = 'https://'. $host .'/'. $path . $form_state['values']['query'];
 
   list($ch, $opts) = pantheon_apachesolr_curl_setup($url, PANTHEON_APACHESOLR_PORT);
@@ -410,12 +514,22 @@ function pantheon_apachesolr_post_schema_form($form, &$form_state) {
 
   $files = drupal_system_listing('/schema.*\.xml$/', 'modules', 'uri', 0);
   $schemas = array();
-  $recommended = '3.x/schema.xml';
+  if (pantheon_apachesolr_get_search_version() == 9) {
+    $recommended = '9.x/schema.xml';
+  }
+  else {
+    $recommended = '3.x/schema.xml';
+  }
+
   $wrong_versions = array(
     '4.x',
     '1.4',
     'extra',
   );
+  if (pantheon_apachesolr_get_search_version() == 9) {
+    $wrong_versions[] = '3.x';
+    $wrong_versions[] = '1.3';
+  }
 
   $default = '';
 
@@ -433,19 +547,41 @@ function pantheon_apachesolr_post_schema_form($form, &$form_state) {
       }
     }
 
-    if (!$recommended && in_array($data->uri, array(
-      'sites/all/modules/apachesolr/solr-conf/solr-3.x/schema.xml',
-      'sites/all/modules/search_api_solr/solr-conf/3.x/schema.xml',
-    ))) {
+    if (pantheon_apachesolr_get_search_version() == 9) {
+      $uris = array(
+        'sites/all/modules/apachesolr/solr-conf/solr-9.x/schema.xml',
+        'sites/all/modules/search_api_solr/solr-conf/9.x/schema.xml',
+      );
+    }
+    else {
+      $uris = array(
+        'sites/all/modules/apachesolr/solr-conf/solr-3.x/schema.xml',
+        'sites/all/modules/search_api_solr/solr-conf/3.x/schema.xml',
+      );
+    }
+
+    if (!$recommended && in_array($data->uri, $uris)) {
       $recommended = $data->uri;
     }
   }
   asort($schemas);
 
+  if (pantheon_apachesolr_get_search_version() == 9) {
+    $translate_parameters = array(
+      '@version' => 'v9.10.0',
+      '@schema' => '9.x/schema.xml',
+    );
+  }
+  else {
+    $translate_parameters = array(
+      '@version' => 'v3.5.0',
+      '@schema' => '3.x/schema.xml',
+    );
+  }
   $form['schemas'] = array(
     '#type' => 'fieldset',
     '#title' => t('Solr Schema File'),
-    '#description' => t('The following schema.xml files exist in your Drupal site code. Pantheon uses Apache Solr v3.5.0, so you should use 3.x/schema.xml as the base configuration.') . '<br/><br/>',
+    '#description' => t('The following schema.xml files exist in your Drupal site code. Pantheon uses Apache Solr @version, so you should use @schema as the base configuration.', $translate_parameters) . '<br/><br/>',
     '#weight' => -10,
   );
   if (count($schemas) > 0) {
@@ -530,7 +666,12 @@ function pantheon_apachesolr_status($form, &$form_state) {
   );
 
   // Ping.
-  $path = 'sites/self/environments/' . variable_get('pantheon_environment', 'dev') . '/index/admin/ping';
+  if (pantheon_apachesolr_get_search_version() == 9) {
+    $path = getenv('PANTHEON_INDEX_PATH') . getenv('PANTHEON_INDEX_CORE') . '/admin/ping';
+  }
+  else {
+    $path = 'sites/self/environments/' . variable_get('pantheon_environment', 'dev') . '/index/admin/ping';
+  }
 
   if ($schema == 'search_api_solr') {
     $path .= '?q=id:1';
@@ -606,7 +747,12 @@ function pantheon_apachesolr_status($form, &$form_state) {
   }
 
   // Solr Stats.
-  $path = 'sites/self/environments/' . variable_get('pantheon_environment', 'dev') . '/index/admin/stats.jsp';
+  if (pantheon_apachesolr_get_search_version() == 9) {
+    $path = getenv('PANTHEON_INDEX_PATH') . getenv('PANTHEON_INDEX_CORE') . '/admin/system';
+  }
+  else {
+    $path = 'sites/self/environments/' . variable_get('pantheon_environment', 'dev') . '/index/admin/stats.jsp';
+  }
   $url = 'https://'. $host . '/' . $path;
 
   $opts = array();
@@ -619,12 +765,22 @@ function pantheon_apachesolr_status($form, &$form_state) {
 
   $response = curl_exec($ch);
   curl_close($ch);
-  $oXML = new SimpleXMLElement($response);
 
-  $debug = array(
-    t('Core') => $oXML->core,
-    t('Schema') => $oXML->schema,
-  );
+  if (pantheon_apachesolr_get_search_version() == 9) {
+    $info = json_decode($response, TRUE);
+    $debug = array(
+      t('Core') => str_replace('/var/solr/data/', '', $info['core']['directory']['instance']),
+      t('Schema') => $info['core']['schema'],
+    );
+  }
+  else {
+    $oXML = new SimpleXMLElement($response);
+
+    $debug = array(
+      t('Core') => $oXML->core,
+      t('Schema') => $oXML->schema,
+    );
+  }
 
   $debug_str = '<h2>' . t('Core and Schema from Solr Server') . '</h2>';
   $debug_str .= '<dl>';
@@ -700,7 +856,12 @@ function pantheon_apachesolr_requirements($phase) {
       ));
       // Ping.
       $host = PANTHEON_APACHESOLR_HOST;
-      $path = 'sites/self/environments/' . variable_get('pantheon_environment', 'dev') . '/index/admin/ping';
+      if (pantheon_apachesolr_get_search_version() == 9) {
+        $path = getenv('PANTHEON_INDEX_PATH') . getenv('PANTHEON_INDEX_CORE') . '/admin/ping';
+      }
+      else {
+        $path = 'sites/self/environments/' . variable_get('pantheon_environment', 'dev') . '/index/admin/ping';
+      }
       $schema = strpos($pantheon_apachesolr_schema, 'search_api_solr') !== FALSE ? 'search_api_solr' : 'generic';
 
       if ($schema == 'search_api_solr') {


### PR DESCRIPTION
## Summary

Adds Solr 9 support for Drupal 7 on Pantheon. Built on top of Promet's Solr 8 work (PR #221), adapted for Solr 9, and integrated with  improvements on `default` branch.

- Merged Promet's branch into the new `SITE-5456-solr9` branch
- Changed all version checks from `== 8` to `== 9` and version strings from `v8.11.0` to `v9.10.0`
- Updated schema paths from `8.x` to `9.x`
- Removed redundant `connect()` override from `PantheonApachesolrSearchApiSolrService` (Solr 9 options already set in `PantheonApachesolrSearchApiSolrConnection::__construct()`)
- Removed legacy dead code: `PantheonSearchApiSolrService` and `PanteheonSearchApiSolrHttpTransport` classes
- Added full Solr 9 support to `Pantheon_Apache_Solr_Service.php` (Promet didn't touch this file since `apachesolr` didn't support Solr 8, but `apachesolr` 7.x-1.14 has built-in Solr 9 support)

## Schema posting: Solr 3 vs Solr 9

| | Solr 3 | Solr 9 |
|---|---|---|
| Endpoint | `sites/self/environments/{env}/index` | `PANTHEON_INDEX_PATH` + `PANTHEON_INDEX_SCHEMA` (search-gateway) |
| Scope | Single `schema.xml` file | Entire config directory (all files) |
| Content type | `text/xml` | `application/json` |
| Method | `PUT` | `POST` |
| Payload | Raw XML file stream (`CURLOPT_INFILE`) | Base64-encoded files as JSON (`CURLOPT_POSTFIELDS`) |

## Module compatibility

| Module | Solr 3 | Solr 9 |
|---|---|---|
| **Apache Solr Search** (`apachesolr`) 7.x-1.15 Latest version from tag1 | :white_check_mark: | :white_check_mark:  |
| **Search API Solr** (`search_api_solr`) 7.x-1.19  Latest version from tag1| :white_check_mark: | :white_check_mark: (Solr 9 support added by Tag1 in 7.x-1.18) |

**Testing**

Tested Solr9 with new sites in production with both of the contributed modules

1. Apache Solr (7.x-1.15)
<img width="1216" height="844" alt="Screenshot 2026-05-01 at 3 03 39 PM" src="https://github.com/user-attachments/assets/0d3ca85e-2089-4faa-89bf-818a0c9a50a4" />

2. Search API Solr
<img width="1686" height="565" alt="Screenshot 2026-05-01 at 3 07 03 PM" src="https://github.com/user-attachments/assets/8d4a4e72-3da5-4aeb-a695-ac234708062e" />

---

## Testing Instructions

- Create a new Drupal 7 site on Pantheon.
- When site creation is finished, visit the dashboard.
- Enable Solr: Dashboard > Settings > Add Ons > Apache Solr Index Server: **Add**.
- Switch to "git" mode.
- Clone your site locally.
- Apply the files from this PR on top of your local checkout.
  - `git remote add drops-7 git@github.com:pantheon-systems/drops-7.git`
  - `git fetch drops-7`
  - `git merge drops-7/SITE-5456-solr9`
- Push your files back up to Pantheon.
- Switch back to sftp mode.
- Visit your site and step through the installation process.

---

## Solr 9 Support in Drupal 7 (Apache Solr Search Module)

### Setting Up Solr 9 in Drupal 7 From Scratch

- Install the following modules:
  - Apache Solr Search version: 7.x-1.15 (available with Tag1 D7ES support)
- Set Solr version to 9 in `pantheon.yml`:
  ```yaml
  search:
    version: 9
  ```
- Push your files back up to Pantheon and wait for the Solr 9 provisioning workflow to complete (check Dashboard > Workflows).
- In your site, enable the following modules:
  - Pantheon Apache Solr
  - Apache Solr Search
  - Apache Solr Search Pages (optional, for search page)
- Configure Pantheon Apache Solr:
  - Configuration > Search and Metadata > Pantheon Apache Solr > Post schema.xml (tab)
  - Choose `sites/all/modules/apachesolr/solr-conf/solr-9.x/schema.xml (recommended)` and click `Post schema`.
  - After waiting for a few minutes, confirm the configuration is updated by checking the `Status` tab.
  - Check some test queries using the `Execute query` tab (try `/admin/ping`).
- Index contents:
  - Configuration > Search and Metadata > Apache Solr search > Queue all content for reindexing
  - Or via drush: `drush solr-mark-all && drush solr-index`
- Test search functionality on the site.

### Switching from Solr 3 to Solr 9 (Apache Solr Search Module)

- Update the site using the latest Drops 7 code base (with these code changes included). (Or at least the Pantheon module inside the `modules` directory).
- Update `apachesolr` to 7.x-1.15 (tag1 D7ES) which includes the `solr-conf/solr-9.x/` schema directory.
- Set Solr version to 9 in `pantheon.yml`:
  ```yaml
  search:
    version: 9
  ```
- Push and wait for the Solr 9 provisioning workflow to complete (check Dashboard > Workflows).
- Configure Pantheon Apache Solr:
  - Configuration > Search and Metadata > Pantheon Apache Solr > Post schema.xml (tab)
  - Choose `sites/all/modules/apachesolr/solr-conf/solr-9.x/schema.xml (recommended)` and click `Post schema`.
  - After waiting for a few minutes, confirm the configuration is updated by checking the `Status` tab.
  - Check some test queries using the `Execute query` tab (try `/admin/ping`).
- Reindex site contents:
  - Configuration > Search and Metadata > Apache Solr search > Queue all content for reindexing
  - Or via drush: `drush solr-mark-all && drush solr-index`

---

## Solr 9 Support in Drupal 7 (Search API Solr Module)

### Setting Up Solr 9 in Drupal 7 From Scratch

- Install the following modules (use the latest versions if needed):
  - Chaos Tools Suite version: 7.x-1.21
  - Entity API version: 7.x-1.11
  - Search API version: 7.x-1.29
  - Search API Solr version: 7.x-1.19 (available via tag1 D7 Extended Support, includes native Solr 9 support)
  - Views
- Set Solr version to 9 in `pantheon.yml`:
  ```yaml
  search:
    version: 9
  ```
- Push your files back up to Pantheon and wait for the Solr 9 provisioning workflow to complete (check Dashboard > Workflows).
- In your site, enable the following modules:
  - Pantheon Apache Solr
  - Search API
  - Search API Solr
- Configure Pantheon Apache Solr:
  - Configuration > Search and Metadata > Pantheon Apache Solr > Post schema.xml (tab)
  - Choose `sites/all/modules/search_api_solr/solr-conf/9.x/schema.xml (recommended)` and click `Post schema`.
  - After waiting for a few minutes, confirm the configuration is updated by checking the `Status` tab.
  - Check some test queries using the `Execute query` tab.
- Configure Search API or create new server and index configuration:
  - Configuration > Search and Metadata > Search API
    - Add a new server, using `Solr service` Service class.
    - Set configuration using these suggested values for Pantheon:
      - HTTP protocol: https
      - Solr host: localhost
      - Solr port: 8983
      - Solr path: /solr
    - Add a new index:
      - Enabled: true
      - Server: the new server created above.
      - The rest of the settings is based on user preference (e.g. `Index items immediately`, `Fields`, `Highlighting` in Filters).
- Index the contents, if there are any.
- Create a Views display that uses the Index with an exposed filter for the query string.

### Switching from Solr 3 to Solr 9 (Search API Solr Module)

- Update the site using the latest Drops 7 code base (with these code changes included). (Or at least the Pantheon module inside the `modules` directory).
- Update `search_api_solr` to 7.x-1.19 (tag1 D7ES) which includes the `solr-conf/9.x/` schema directory.
- Set Solr version to 9 in `pantheon.yml`:
  ```yaml
  search:
    version: 9
  ```
- Push and wait for the Solr 9 provisioning workflow to complete (check Dashboard > Workflows).
- Configure Pantheon Apache Solr:
  - Configuration > Search and Metadata > Pantheon Apache Solr > Post schema.xml (tab)
  - Choose `sites/all/modules/search_api_solr/solr-conf/9.x/schema.xml (recommended)` and click `Post schema`.
  - After waiting for a few minutes, confirm the configuration is updated by checking the `Status` tab.
  - Check some test queries using the `Execute query` tab.
- Run any pending Search API tasks if there are alerts.
- Reindex site contents.

---

## Jira

SITE-5456