### PR TITLE
ci: [SITE-5766] Solr 9 CUJ tests for D7 pantheon_apachesolr

### DIFF
--- a/.github/scripts/solr9-bootstrap-fixture.sh
+++ b/.github/scripts/solr9-bootstrap-fixture.sh
@@ -26,7 +26,6 @@ show_help() {
     echo "  -n <arg>         Site name (e.g. search-api-pantheon-d7)"
     echo "  -o <arg>         Organization name or UUID (required)"
     echo "  -h               Show help"
-    exit 1
 }
 
 main() {
@@ -37,8 +36,8 @@ main() {
         case $opt in
             n) SITE_NAME="$OPTARG" ;;
             o) ORG="$OPTARG" ;;
-            h) show_help ;;
-            *) show_help ;;
+            h) show_help; exit 0 ;;
+            *) show_help; exit 1 ;;
         esac
     done
 
@@ -47,11 +46,13 @@ main() {
     if [[ -z "$SITE_NAME" ]]; then
         echo "ERROR: -n <site-name> is required"
         show_help
+        exit 1
     fi
 
     if [[ -z "$ORG" ]]; then
         echo "ERROR: -o <org> is required"
         show_help
+        exit 1
     fi
 
     local SITE_NAME_LC
@@ -72,7 +73,7 @@ main() {
         exit 1
     fi
 
-    echo "[1/5] Creating site..."
+    echo "[1/6] Creating site..."
     terminus site:create "$SITE_NAME" "$SITE_NAME" "drupal7" --org="$ORG"
     echo "Waiting for site creation workflow..."
     terminus workflow:wait "$SITE_ENV"
@@ -83,7 +84,7 @@ main() {
     # -----------------------------------------------------------------------
     # Step 2: Upgrade plan + enable Solr
     # -----------------------------------------------------------------------
-    echo "[2/5] Configuring plan and Solr..."
+    echo "[2/6] Configuring plan and Solr..."
     local CURRENT_PLAN
     CURRENT_PLAN=$(terminus site:info "$SITE_NAME_LC" --field=plan_name 2>/dev/null || echo "")
     if [[ "$CURRENT_PLAN" == *"Sandbox"* ]]; then
@@ -100,6 +101,10 @@ main() {
     # Step 3: Set Solr version 9 in pantheon.yml (inherited by all multidevs)
     # -----------------------------------------------------------------------
     echo "[3/6] Setting Solr version 9 in pantheon.yml..."
+    # pantheon.yml changes are committed over git, so the env must be in git mode.
+    # A freshly created site defaults to SFTP mode, which rejects pushes.
+    terminus connection:set "$SITE_ENV" git
+    terminus workflow:wait "$SITE_ENV"
     local GIT_URL
     GIT_URL=$(terminus connection:info "$SITE_ENV" --field=git_url)
     rm -rf /tmp/bootstrap-pantheon-site
@@ -108,7 +113,9 @@ main() {
         cd /tmp/bootstrap-pantheon-site
         touch pantheon.yml
         if grep -q "^search:" pantheon.yml; then
-            sed -i "s/^\([[:space:]]*\)version: [0-9]*/\1version: 9/" pantheon.yml
+            # sed -i.bak keeps this portable across GNU (Linux/GHA) and BSD (macOS) sed.
+            sed -i.bak "s/^\([[:space:]]*\)version: [0-9]*/\1version: 9/" pantheon.yml
+            rm -f pantheon.yml.bak
         else
             echo "search:" >> pantheon.yml
             echo "  version: 9" >> pantheon.yml
@@ -116,7 +123,15 @@ main() {
         echo "pantheon.yml contents:"
         cat pantheon.yml
         git add pantheon.yml
-        git commit -m "Set Solr version to 9 for CUJ fixture" || echo "No changes to commit"
+        # Only commit when there is a staged change. A real commit failure
+        # (e.g. gpg signing, pre-commit hook) must abort rather than be
+        # swallowed, otherwise the push silently lands nothing and the
+        # fixture ends up without search: version: 9.
+        if ! git diff --cached --quiet; then
+            git commit -m "Set Solr version to 9 for CUJ fixture"
+        else
+            echo "No changes to commit"
+        fi
         git push origin HEAD
     )
     terminus workflow:wait "$SITE_ENV"
@@ -126,6 +141,10 @@ main() {
     # Step 4: Install Drupal
     # -----------------------------------------------------------------------
     echo "[4/6] Installing Drupal..."
+    # site-install writes settings.php, which requires SFTP (read/write) mode.
+    # Git mode mounts the code read-only and the install fails with "Permission denied".
+    terminus connection:set "$SITE_ENV" sftp
+    terminus workflow:wait "$SITE_ENV"
     local ADMIN_PASS
     ADMIN_PASS=$(openssl rand -base64 18)
     if terminus drush "$SITE_ENV" -- status --field=bootstrap 2>/dev/null | grep -q "Successful"; then
@@ -184,7 +203,10 @@ foreach ($articles as $a) {
     # -----------------------------------------------------------------------
     echo "[6/6] Verifying setup..."
 
-    terminus drush "$SITE_ENV" -- ev '
+    # Capture output and assert on a success marker rather than trusting the
+    # drush PHP exit code to propagate through terminus.
+    local VERIFY_OUT
+    VERIFY_OUT=$(terminus drush "$SITE_ENV" -- ev '
 $count = db_query("SELECT COUNT(*) FROM {node}")->fetchField();
 if ($count < 20) {
   echo "FAIL: Expected 20 nodes, found " . $count . "\n";
@@ -197,7 +219,12 @@ echo "Nodes containing Solr: " . $solr_check . "\n";
 
 $terminus_check = db_query("SELECT COUNT(*) FROM {node} WHERE title LIKE :pattern", array(":pattern" => "%Terminus%"))->fetchField();
 echo "Nodes containing Terminus: " . $terminus_check . "\n";
-'
+' 2>&1)
+    echo "$VERIFY_OUT"
+    if ! echo "$VERIFY_OUT" | grep -q "(OK)"; then
+        echo "ERROR: Verification failed (expected 20 nodes)."
+        exit 1
+    fi
 
     echo ""
     echo "=== Bootstrap complete ==="

--- a/.github/scripts/solr9-bootstrap-fixture.sh
+++ b/.github/scripts/solr9-bootstrap-fixture.sh
@@ -97,9 +97,35 @@ main() {
     terminus solr:enable "$SITE_ID" 2>/dev/null || echo "[skip] Solr already enabled or enable failed"
 
     # -----------------------------------------------------------------------
-    # Step 3: Install Drupal
+    # Step 3: Set Solr version 9 in pantheon.yml (inherited by all multidevs)
     # -----------------------------------------------------------------------
-    echo "[3/5] Installing Drupal..."
+    echo "[3/6] Setting Solr version 9 in pantheon.yml..."
+    local GIT_URL
+    GIT_URL=$(terminus connection:info "$SITE_ENV" --field=git_url)
+    rm -rf /tmp/bootstrap-pantheon-site
+    GIT_SSH_COMMAND="ssh -o StrictHostKeyChecking=no" git clone "$GIT_URL" /tmp/bootstrap-pantheon-site
+    (
+        cd /tmp/bootstrap-pantheon-site
+        touch pantheon.yml
+        if grep -q "^search:" pantheon.yml; then
+            sed -i "s/^\([[:space:]]*\)version: [0-9]*/\1version: 9/" pantheon.yml
+        else
+            echo "search:" >> pantheon.yml
+            echo "  version: 9" >> pantheon.yml
+        fi
+        echo "pantheon.yml contents:"
+        cat pantheon.yml
+        git add pantheon.yml
+        git commit -m "Set Solr version to 9 for CUJ fixture" || echo "No changes to commit"
+        git push origin HEAD
+    )
+    terminus workflow:wait "$SITE_ENV"
+    rm -rf /tmp/bootstrap-pantheon-site
+
+    # -----------------------------------------------------------------------
+    # Step 4: Install Drupal
+    # -----------------------------------------------------------------------
+    echo "[4/6] Installing Drupal..."
     local ADMIN_PASS
     ADMIN_PASS=$(openssl rand -base64 18)
     if terminus drush "$SITE_ENV" -- status --field=bootstrap 2>/dev/null | grep -q "Successful"; then
@@ -113,9 +139,9 @@ main() {
     fi
 
     # -----------------------------------------------------------------------
-    # Step 4: Create 20 article nodes with real content
+    # Step 5: Create 20 article nodes with real content
     # -----------------------------------------------------------------------
-    echo "[4/5] Creating article nodes..."
+    echo "[5/6] Creating article nodes..."
 
     terminus drush "$SITE_ENV" -- ev '
 $articles = array(
@@ -154,9 +180,9 @@ foreach ($articles as $a) {
 '
 
     # -----------------------------------------------------------------------
-    # Step 4: Verify setup
+    # Step 6: Verify setup
     # -----------------------------------------------------------------------
-    echo "[5/5] Verifying setup..."
+    echo "[6/6] Verifying setup..."
 
     terminus drush "$SITE_ENV" -- ev '
 $count = db_query("SELECT COUNT(*) FROM {node}")->fetchField();

--- a/.github/scripts/solr9-bootstrap-fixture.sh
+++ b/.github/scripts/solr9-bootstrap-fixture.sh
@@ -100,13 +100,15 @@ main() {
     # Step 3: Install Drupal
     # -----------------------------------------------------------------------
     echo "[3/5] Installing Drupal..."
+    local ADMIN_PASS
+    ADMIN_PASS=$(openssl rand -base64 18)
     if terminus drush "$SITE_ENV" -- status --field=bootstrap 2>/dev/null | grep -q "Successful"; then
         echo "[skip] Drupal already installed"
     else
         terminus drush "$SITE_ENV" -- site-install standard \
             --site-name="D7 Solr 9 CI" \
             --account-name=admin \
-            --account-pass=admin \
+            --account-pass="$ADMIN_PASS" \
             -y
     fi
 
@@ -176,7 +178,8 @@ echo "Nodes containing Terminus: " . $terminus_check . "\n";
     echo "Site: ${SITE_NAME_LC}"
     echo "Site ID: ${SITE_ID}"
     echo "Dev URL: https://dev-${SITE_NAME_LC}.pantheonsite.io"
-    echo "Admin: admin / admin"
+    echo "Admin: admin / ${ADMIN_PASS}"
+    echo "(generated; re-login any time with: terminus drush ${SITE_ENV} -- uli)"
     echo ""
     echo "Next steps:"
     echo "  1. Add TERMINUS_TOKEN, PANTHEON_SSH_KEY secrets to the drops-7 repo"

--- a/.github/scripts/solr9-bootstrap-fixture.sh
+++ b/.github/scripts/solr9-bootstrap-fixture.sh
@@ -15,24 +15,23 @@ set -eou pipefail
 #   5. Verification
 #
 # Examples:
-#   .github/scripts/solr9-bootstrap-fixture.sh -n search-api-pantheon-d7
-#   .github/scripts/solr9-bootstrap-fixture.sh -n search-api-pantheon-d7 -o "CI Fixtures for Projects"
+#   .github/scripts/solr9-bootstrap-fixture.sh -n search-api-pantheon-d7 -o "<org-name-or-uuid>"
 #
 # Prerequisites:
 #   - terminus authenticated (terminus auth:whoami)
 
 show_help() {
-    echo "Usage: $0 -n <site-name> [-o <org>]"
+    echo "Usage: $0 -n <site-name> -o <org>"
     echo "Options:"
     echo "  -n <arg>         Site name (e.g. search-api-pantheon-d7)"
-    echo "  -o <arg>         Organization name or UUID (default: CI Fixtures for Projects)"
+    echo "  -o <arg>         Organization name or UUID (required)"
     echo "  -h               Show help"
     exit 1
 }
 
 main() {
     local SITE_NAME=""
-    local ORG="CI Fixtures for Projects"
+    local ORG=""
 
     while getopts "n:o:h" opt; do
         case $opt in
@@ -47,6 +46,11 @@ main() {
 
     if [[ -z "$SITE_NAME" ]]; then
         echo "ERROR: -n <site-name> is required"
+        show_help
+    fi
+
+    if [[ -z "$ORG" ]]; then
+        echo "ERROR: -o <org> is required"
         show_help
     fi
 

--- a/.github/scripts/solr9-bootstrap-fixture.sh
+++ b/.github/scripts/solr9-bootstrap-fixture.sh
@@ -1,28 +1,117 @@
-#!/bin/bash
-set -euo pipefail
+#!/usr/bin/env bash
+set -eou pipefail
 
-# Bootstrap the D7 Solr 9 CI fixture site from scratch.
-# Installs Drupal and seeds 20 article nodes with real content.
-# Idempotent: drops existing DB and reinstalls.
+# Bootstrap a D7 Solr 9 CI fixture site from scratch.
 #
-# Usage: bash solr9-bootstrap-fixture.sh <site-name> <env>
-# Example: bash solr9-bootstrap-fixture.sh search-api-pantheon-d7 dev
+# Recreates the full dev environment that Solr 9 CUJ tests depend on.
+# Run this if the fixture site is destroyed, corrupted, or needs to be
+# rebuilt from zero.
+#
+# What it sets up:
+#   1. Pantheon site on Drupal 7 upstream
+#   2. Solr add-on enabled
+#   3. Drupal install with admin credentials
+#   4. 20 article nodes with real, searchable content
+#   5. Verification
+#
+# Examples:
+#   .github/scripts/solr9-bootstrap-fixture.sh -n search-api-pantheon-d7
+#   .github/scripts/solr9-bootstrap-fixture.sh -n search-api-pantheon-d7 -o "CI Fixtures for Projects"
+#
+# Prerequisites:
+#   - terminus authenticated (terminus auth:whoami)
 
-SITE="${1:?Usage: $0 <site-name> <env>}"
-ENV="${2:-dev}"
-SITE_ENV="$SITE.$ENV"
+show_help() {
+    echo "Usage: $0 -n <site-name> [-o <org>]"
+    echo "Options:"
+    echo "  -n <arg>         Site name (e.g. search-api-pantheon-d7)"
+    echo "  -o <arg>         Organization name or UUID (default: CI Fixtures for Projects)"
+    echo "  -h               Show help"
+    exit 1
+}
 
-echo "=== Bootstrapping fixture site: $SITE_ENV ==="
+main() {
+    local SITE_NAME=""
+    local ORG="CI Fixtures for Projects"
 
-echo "--- Installing Drupal ---"
-terminus drush "$SITE_ENV" -- site-install standard \
-  --site-name="D7 Solr 9 CI" \
-  --account-name=admin \
-  --account-pass=admin \
-  -y
+    while getopts "n:o:h" opt; do
+        case $opt in
+            n) SITE_NAME="$OPTARG" ;;
+            o) ORG="$OPTARG" ;;
+            h) show_help ;;
+            *) show_help ;;
+        esac
+    done
 
-echo "--- Creating article nodes ---"
-terminus drush "$SITE_ENV" -- ev '
+    shift "$((OPTIND-1))"
+
+    if [[ -z "$SITE_NAME" ]]; then
+        echo "ERROR: -n <site-name> is required"
+        show_help
+    fi
+
+    local SITE_NAME_LC
+    SITE_NAME_LC=$(echo "$SITE_NAME" | tr '[:upper:]' '[:lower:]')
+    local SITE_ENV="${SITE_NAME_LC}.dev"
+
+    echo "=== Bootstrap D7 Solr 9 CI Fixture Site ==="
+    echo "Site: ${SITE_NAME}"
+    echo "Org: ${ORG}"
+    echo ""
+
+    # -----------------------------------------------------------------------
+    # Step 1: Create site (exit if exists)
+    # -----------------------------------------------------------------------
+    if terminus site:info "$SITE_NAME_LC" &>/dev/null; then
+        echo "ERROR: Site ${SITE_NAME} already exists. Exiting to avoid modifying an existing site."
+        echo "Delete it first if you want to recreate: terminus site:delete ${SITE_NAME_LC}"
+        exit 1
+    fi
+
+    echo "[1/5] Creating site..."
+    terminus site:create "$SITE_NAME" "$SITE_NAME" "drupal7" --org="$ORG"
+    echo "Waiting for site creation workflow..."
+    terminus workflow:wait "$SITE_ENV"
+
+    local SITE_ID
+    SITE_ID=$(terminus site:info "$SITE_NAME_LC" --field=ID)
+
+    # -----------------------------------------------------------------------
+    # Step 2: Upgrade plan + enable Solr
+    # -----------------------------------------------------------------------
+    echo "[2/5] Configuring plan and Solr..."
+    local CURRENT_PLAN
+    CURRENT_PLAN=$(terminus site:info "$SITE_NAME_LC" --field=plan_name 2>/dev/null || echo "")
+    if [[ "$CURRENT_PLAN" == *"Sandbox"* ]]; then
+        echo "Upgrading to Performance Small..."
+        terminus plan:set "$SITE_ID" "plan-performance_small-contract-annual-1"
+    else
+        echo "[skip] Already on plan: ${CURRENT_PLAN}"
+    fi
+
+    echo "Enabling Solr..."
+    terminus solr:enable "$SITE_ID" 2>/dev/null || echo "[skip] Solr already enabled or enable failed"
+
+    # -----------------------------------------------------------------------
+    # Step 3: Install Drupal
+    # -----------------------------------------------------------------------
+    echo "[3/5] Installing Drupal..."
+    if terminus drush "$SITE_ENV" -- status --field=bootstrap 2>/dev/null | grep -q "Successful"; then
+        echo "[skip] Drupal already installed"
+    else
+        terminus drush "$SITE_ENV" -- site-install standard \
+            --site-name="D7 Solr 9 CI" \
+            --account-name=admin \
+            --account-pass=admin \
+            -y
+    fi
+
+    # -----------------------------------------------------------------------
+    # Step 4: Create 20 article nodes with real content
+    # -----------------------------------------------------------------------
+    echo "[4/5] Creating article nodes..."
+
+    terminus drush "$SITE_ENV" -- ev '
 $articles = array(
   array("Getting Started with Apache Solr on Pantheon", "Apache Solr is a powerful open-source search platform built on Apache Lucene. Pantheon provides managed Solr instances for every environment, enabling fast full-text search across your Drupal content. This guide covers initial setup, schema posting, and indexing your first batch of content."),
   array("Understanding Drupal Content Types and Fields", "Drupal organizes content into types such as articles, pages, and custom bundles. Each content type can have fields for text, images, taxonomy references, and more. Properly structured content types improve both editorial workflow and search relevance."),
@@ -56,11 +145,41 @@ foreach ($articles as $a) {
   node_save($node);
   echo "Created: " . $node->title . "\n";
 }
-echo "BOOTSTRAP_COMPLETE";
 '
 
-echo "--- Verifying ---"
-NODE_COUNT=$(terminus drush "$SITE_ENV" -- ev "echo db_query('SELECT COUNT(*) FROM {node}')->fetchField();" 2>&1 | head -1)
-echo "Node count: $NODE_COUNT"
+    # -----------------------------------------------------------------------
+    # Step 4: Verify setup
+    # -----------------------------------------------------------------------
+    echo "[5/5] Verifying setup..."
 
-echo "=== Fixture site $SITE_ENV bootstrapped with $NODE_COUNT articles ==="
+    terminus drush "$SITE_ENV" -- ev '
+$count = db_query("SELECT COUNT(*) FROM {node}")->fetchField();
+if ($count < 20) {
+  echo "FAIL: Expected 20 nodes, found " . $count . "\n";
+  exit(1);
+}
+echo "Node count: " . $count . " (OK)\n";
+
+$solr_check = db_query("SELECT COUNT(*) FROM {node} WHERE title LIKE :pattern", array(":pattern" => "%Solr%"))->fetchField();
+echo "Nodes containing Solr: " . $solr_check . "\n";
+
+$terminus_check = db_query("SELECT COUNT(*) FROM {node} WHERE title LIKE :pattern", array(":pattern" => "%Terminus%"))->fetchField();
+echo "Nodes containing Terminus: " . $terminus_check . "\n";
+'
+
+    echo ""
+    echo "=== Bootstrap complete ==="
+    echo "Site: ${SITE_NAME_LC}"
+    echo "Site ID: ${SITE_ID}"
+    echo "Dev URL: https://dev-${SITE_NAME_LC}.pantheonsite.io"
+    echo "Admin: admin / admin"
+    echo ""
+    echo "Next steps:"
+    echo "  1. Add TERMINUS_TOKEN, PANTHEON_SSH_KEY secrets to the drops-7 repo"
+    echo "  2. Add PANTHEON_SITE_D7 repo variable = ${SITE_NAME_LC}"
+    echo ""
+    echo "CI multidevs will inherit article content from dev."
+    echo "Modules (apachesolr, search_api_solr) are installed per-multidev by solr9-setup-multidev.sh."
+}
+
+main "$@"

--- a/.github/scripts/solr9-bootstrap-fixture.sh
+++ b/.github/scripts/solr9-bootstrap-fixture.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+set -euo pipefail
+
+# Bootstrap the D7 Solr 9 CI fixture site from scratch.
+# Installs Drupal and seeds 20 article nodes with real content.
+# Idempotent: drops existing DB and reinstalls.
+#
+# Usage: bash solr9-bootstrap-fixture.sh <site-name> <env>
+# Example: bash solr9-bootstrap-fixture.sh search-api-pantheon-d7 dev
+
+SITE="${1:?Usage: $0 <site-name> <env>}"
+ENV="${2:-dev}"
+SITE_ENV="$SITE.$ENV"
+
+echo "=== Bootstrapping fixture site: $SITE_ENV ==="
+
+echo "--- Installing Drupal ---"
+terminus drush "$SITE_ENV" -- site-install standard \
+  --site-name="D7 Solr 9 CI" \
+  --account-name=admin \
+  --account-pass=admin \
+  -y
+
+echo "--- Creating article nodes ---"
+terminus drush "$SITE_ENV" -- ev '
+$articles = array(
+  array("Getting Started with Apache Solr on Pantheon", "Apache Solr is a powerful open-source search platform built on Apache Lucene. Pantheon provides managed Solr instances for every environment, enabling fast full-text search across your Drupal content. This guide covers initial setup, schema posting, and indexing your first batch of content."),
+  array("Understanding Drupal Content Types and Fields", "Drupal organizes content into types such as articles, pages, and custom bundles. Each content type can have fields for text, images, taxonomy references, and more. Properly structured content types improve both editorial workflow and search relevance."),
+  array("WordPress to Drupal Migration Best Practices", "Migrating from WordPress to Drupal requires careful planning around content mapping, URL redirects, and user account migration. The Migrate module provides a framework for pulling content from external sources including WordPress databases and XML exports."),
+  array("Performance Optimization for High Traffic Websites", "High traffic websites require careful attention to caching, database query optimization, and CDN configuration. Pantheon Global CDN provides edge caching with surrogate key purging, while Varnish handles full-page caching at the platform level."),
+  array("Search Engine Optimization Techniques for Drupal", "Effective SEO in Drupal involves clean URL structures, proper meta tag configuration, XML sitemaps, and structured data markup. The Pathauto module generates search-friendly URLs automatically based on content patterns."),
+  array("Configuring Multidev Environments on Pantheon", "Multidev environments allow teams to work on parallel feature branches without interfering with each other. Each multidev gets its own database, files, and server environment cloned from an existing environment."),
+  array("Database Backup and Recovery Strategies", "Regular database backups are essential for disaster recovery. Pantheon provides automated daily backups and on-demand backup creation. Recovery involves downloading the backup archive and importing it into the target environment."),
+  array("Custom Module Development in Drupal 7", "Building custom modules in Drupal 7 follows the hook system architecture. Modules implement hooks like hook_menu, hook_form_alter, and hook_node_view to extend core functionality. The module .info file declares dependencies and metadata."),
+  array("Solr Schema Configuration and Field Mapping", "The Solr schema defines how content fields are indexed and searched. Field types control tokenization, stemming, and analysis chains. Proper field mapping ensures that search queries return relevant results with appropriate boosting."),
+  array("Terminus Command Line Interface Reference", "Terminus is the command line interface for Pantheon. It provides commands for site management, environment operations, and workflow automation. Common commands include site creation, database operations, and deployment workflows."),
+  array("Managing SSL Certificates for Custom Domains", "Custom domains on Pantheon require DNS configuration and SSL certificate provisioning. The platform provides free automated HTTPS through Let us Encrypt. Proper DNS setup includes A records, CNAME records, and CAA records for certificate authority authorization."),
+  array("Cron Job Scheduling and Automation in Drupal", "Drupal cron runs periodic maintenance tasks including content indexing, cache clearing, and queue processing. On Pantheon, cron runs automatically every hour. Custom cron intervals can be configured using the Elysia Cron module or hook_cron implementations."),
+  array("User Authentication and Role Management", "Drupal provides a robust permission system with roles and granular access controls. Users can be assigned multiple roles, each granting specific permissions. SAML and OAuth integrations enable single sign-on with external identity providers."),
+  array("Responsive Theme Development with Drupal 7", "Building responsive themes in Drupal 7 requires media queries, fluid grids, and flexible images. The theme layer uses template files, preprocess functions, and the render API. Mobile-first design ensures optimal experience across devices."),
+  array("Version Control Workflows for Drupal Teams", "Git-based workflows on Pantheon support feature branching, code review, and automated deployments. Teams typically use a trunk-based development model with short-lived feature branches. Pull requests enable peer review before merging to the main branch."),
+  array("Debugging PHP Errors and Watchdog Logs", "Drupal watchdog logs capture errors, warnings, and informational messages from modules and core. The dblog module stores entries in the database accessible at admin reports dblog. Common PHP errors include undefined function calls, memory limits, and deprecated function usage."),
+  array("Taxonomy and Vocabulary Configuration Guide", "Taxonomy provides hierarchical classification for Drupal content. Vocabularies group related terms, and term references connect content to classification schemes. Faceted search leverages taxonomy to filter results by category, tag, or other classification dimensions."),
+  array("Integrating Third Party APIs with Drupal", "Drupal modules can consume external APIs using drupal_http_request or the Guzzle HTTP client. API keys and credentials should be stored securely using the Key module or environment variables. Rate limiting and caching prevent excessive API calls."),
+  array("Content Moderation and Editorial Workflows", "Editorial workflows in Drupal manage content through draft, review, and published states. The Workbench Moderation module provides configurable states and transitions. Role-based permissions control who can create, edit, and publish content at each stage."),
+  array("Redis Object Caching for Improved Performance", "Redis provides in-memory object caching that reduces database queries and improves page load times. Pantheon offers Redis as a platform service with automatic failover. The Redis module integrates Drupal cache bins with the Redis backend for persistent object storage."),
+);
+foreach ($articles as $a) {
+  $node = new stdClass();
+  $node->type = "article";
+  $node->title = $a[0];
+  $node->language = LANGUAGE_NONE;
+  $node->body[LANGUAGE_NONE][0] = array("value" => $a[1], "format" => "filtered_html");
+  $node->status = 1;
+  $node->promote = 1;
+  node_save($node);
+  echo "Created: " . $node->title . "\n";
+}
+echo "BOOTSTRAP_COMPLETE";
+'
+
+echo "--- Verifying ---"
+NODE_COUNT=$(terminus drush "$SITE_ENV" -- ev "echo db_query('SELECT COUNT(*) FROM {node}')->fetchField();" 2>&1 | head -1)
+echo "Node count: $NODE_COUNT"
+
+echo "=== Fixture site $SITE_ENV bootstrapped with $NODE_COUNT articles ==="

--- a/.github/scripts/solr9-cuj6-configure-server.sh
+++ b/.github/scripts/solr9-cuj6-configure-server.sh
@@ -10,11 +10,9 @@ MODULE="${MODULE:?MODULE env var must be set}"
 
 step() { echo ""; echo ">>>>>>>>>> $1 <<<<<<<<<<"; echo ""; }
 
-# Helper: run drush ev and extract only lines matching a pattern, suppressing terminus noise
-drush_ev_extract() {
-  local pattern="$1"
-  shift
-  terminus drush "$SITE_ENV" -- ev "$@" 2>&1 | grep -o "${pattern}[^ ]*" || true
+# Helper: run drush ev, suppress terminus stderr noise, return clean stdout
+drush_ev() {
+  terminus drush "$SITE_ENV" -- ev "$@" 2>/dev/null | tr -d '[:space:]'
 }
 
 step "CUJ 6: Configure Solr Server ($MODULE)"
@@ -34,7 +32,7 @@ MAX_RETRIES=3
 RETRY_DELAY=60
 for attempt in $(seq 1 $MAX_RETRIES); do
   echo "Schema post attempt $attempt of $MAX_RETRIES..."
-  RESULT=$(drush_ev_extract "SCHEMA_" "
+  RESULT=$(drush_ev "
     variable_set('pantheon_apachesolr_schema', '$SCHEMA_PATH');
     \$result = pantheon_apachesolr_post_schema_exec('$SCHEMA_PATH');
     echo \$result ? 'SCHEMA_POSTED' : 'SCHEMA_FAILED';
@@ -56,7 +54,7 @@ done
 
 step "Step 2: Verify Solr ping"
 
-PING_RESULT=$(drush_ev_extract "PING_" "
+PING_RESULT=$(drush_ev "
   \$host = PANTHEON_APACHESOLR_HOST;
   \$path = getenv('PANTHEON_INDEX_PATH') . getenv('PANTHEON_INDEX_CORE') . '/admin/ping';
   if ('$MODULE' === 'search_api_solr') {
@@ -84,23 +82,22 @@ fi
 step "Step 3: Module-specific verification"
 
 # Get Solr version for reporting
-SOLR_VER=$(drush_ev_extract "SOLR_VER:" "echo 'SOLR_VER:' . (isset(\$_ENV['search_version']) ? \$_ENV['search_version'] : 'unknown');")
-SOLR_VER="${SOLR_VER#SOLR_VER:}"
+SOLR_VER=$(drush_ev "echo \$_ENV['search_version'] ?? 'unknown';")
 
 if [ "$MODULE" = "apachesolr" ]; then
-  ENV_URL=$(drush_ev_extract "ENV_OK:" "
+  ENV_URL=$(drush_ev "
     \$env_id = apachesolr_default_environment();
     if (\$env_id) {
       \$env = apachesolr_environment_load(\$env_id);
-      echo 'ENV_OK:' . \$env['url'];
+      echo \$env['url'];
     } else {
       echo 'ENV_MISSING';
     }
   ")
 
-  if echo "$ENV_URL" | grep -q "ENV_OK:"; then
+  if [ "$ENV_URL" != "ENV_MISSING" ] && [ -n "$ENV_URL" ]; then
     echo "Apache Solr default environment configured (Solr $SOLR_VER)."
-    echo "URL: ${ENV_URL#ENV_OK:}"
+    echo "URL: $ENV_URL"
   else
     echo "::error::Apache Solr default environment not found"
     exit 1
@@ -108,7 +105,7 @@ if [ "$MODULE" = "apachesolr" ]; then
 
 elif [ "$MODULE" = "search_api_solr" ]; then
   echo "Creating Search API server..."
-  SERVER_RESULT=$(drush_ev_extract "SERVER_" "
+  SERVER_RESULT=$(drush_ev "
     \$server = entity_create('search_api_server', array(
       'name' => 'Pantheon Solr 9',
       'machine_name' => 'pantheon_solr9',
@@ -128,7 +125,7 @@ elif [ "$MODULE" = "search_api_solr" ]; then
     exit 1
   fi
 
-  STATUS=$(drush_ev_extract "SERVER_" "
+  STATUS=$(drush_ev "
     \$server = search_api_server_load('pantheon_solr9');
     echo (\$server && \$server->ping()) ? 'SERVER_CONNECTED' : 'SERVER_DISCONNECTED';
   ")

--- a/.github/scripts/solr9-cuj6-configure-server.sh
+++ b/.github/scripts/solr9-cuj6-configure-server.sh
@@ -107,7 +107,25 @@ elif [ "$MODULE" = "search_api_solr" ]; then
       'class' => 'search_api_solr_service',
       'enabled' => 1,
       'description' => 'Solr 9 server on Pantheon',
-      'options' => array('clean_ids' => TRUE),
+      'options' => array(
+        'clean_ids' => 1,
+        'site_hash' => 1,
+        'scheme' => 'http',
+        'host' => 'localhost',
+        'port' => 8983,
+        'path' => '/solr',
+        'http_user' => '',
+        'http_pass' => '',
+        'excerpt' => 0,
+        'retrieve_data' => 0,
+        'highlight_data' => 0,
+        'skip_schema_check' => 0,
+        'solr_version' => '',
+        'http_method' => 'AUTO',
+        'log_query' => 0,
+        'log_response' => 0,
+        'commits_disabled' => 0,
+      ),
     ));
     \$server->save();
     echo \$server->machine_name ? 'SERVER_CREATED' : 'SERVER_FAILED';

--- a/.github/scripts/solr9-cuj6-configure-server.sh
+++ b/.github/scripts/solr9-cuj6-configure-server.sh
@@ -8,11 +8,8 @@ set -euo pipefail
 SITE_ENV="${TERMINUS_SITE}.${MULTIDEV}"
 MODULE="${MODULE:?MODULE env var must be set}"
 
-step() { echo ""; echo ">>>>>>>>>> $1 <<<<<<<<<<"; echo ""; }
-
-drush_ev() {
-  terminus drush "$SITE_ENV" -- ev "$@" 2>&1
-}
+# shellcheck source=.github/scripts/solr9-shared.sh
+source "$(dirname "$0")/solr9-shared.sh"
 
 step "CUJ 6: Configure Solr Server ($MODULE)"
 

--- a/.github/scripts/solr9-cuj6-configure-server.sh
+++ b/.github/scripts/solr9-cuj6-configure-server.sh
@@ -12,7 +12,7 @@ step() { echo ""; echo ">>>>>>>>>> $1 <<<<<<<<<<"; echo ""; }
 
 # Helper: run drush ev, suppress terminus stderr noise, return clean stdout
 drush_ev() {
-  terminus drush "$SITE_ENV" -- ev "$@" 2>/dev/null | tr -d '[:space:]'
+  terminus drush "$SITE_ENV" -- ev "$@" 2>/dev/null | tail -1 | tr -d '[:space:]'
 }
 
 step "CUJ 6: Configure Solr Server ($MODULE)"

--- a/.github/scripts/solr9-cuj6-configure-server.sh
+++ b/.github/scripts/solr9-cuj6-configure-server.sh
@@ -88,8 +88,13 @@ echo "--- Step 3: Module-specific verification ---"
 if [ "$MODULE" = "apachesolr" ]; then
   # Apache Solr Search auto-configures. Verify default environment exists.
   ENV_CHECK=$(terminus drush "$SITE_ENV" -- ev "
-    \$env = apachesolr_default_environment();
-    echo \$env ? 'ENV_OK:' . \$env['url'] : 'ENV_MISSING';
+    \$env_id = apachesolr_default_environment();
+    if (\$env_id) {
+      \$env = apachesolr_environment_load(\$env_id);
+      echo 'ENV_OK:' . \$env['url'];
+    } else {
+      echo 'ENV_MISSING';
+    }
   " 2>&1)
 
   if echo "$ENV_CHECK" | grep -q "ENV_OK"; then
@@ -101,12 +106,13 @@ if [ "$MODULE" = "apachesolr" ]; then
 
 elif [ "$MODULE" = "search_api_solr" ]; then
   # Search API Solr needs a server created programmatically
+  # Service class is search_api_solr_service (Pantheon overrides it internally)
   echo "Creating Search API server..."
   SERVER_RESULT=$(terminus drush "$SITE_ENV" -- ev "
     \$server = entity_create('search_api_server', array(
       'name' => 'Pantheon Solr 9',
       'machine_name' => 'pantheon_solr9',
-      'class' => 'PantheonApachesolrSearchApiSolrService',
+      'class' => 'search_api_solr_service',
       'enabled' => 1,
       'description' => 'Solr 9 server on Pantheon',
       'options' => array('clean_ids' => TRUE),

--- a/.github/scripts/solr9-cuj6-configure-server.sh
+++ b/.github/scripts/solr9-cuj6-configure-server.sh
@@ -8,10 +8,16 @@ set -euo pipefail
 SITE_ENV="${TERMINUS_SITE}.${MULTIDEV}"
 MODULE="${MODULE:?MODULE env var must be set}"
 
-echo "=== CUJ 6: Configure Solr Server ($MODULE) ==="
+step() { echo ""; echo ">>>>>>>>>> $1 <<<<<<<<<<"; echo ""; }
 
-# Step 1: Post Solr 9 schema
-echo "--- Step 1: Post Solr 9 schema ---"
+# Helper: run drush ev and extract only lines matching a pattern, suppressing terminus noise
+drush_ev_extract() {
+  local pattern="$1"
+  shift
+  terminus drush "$SITE_ENV" -- ev "$@" 2>&1 | grep -o "${pattern}[^ ]*" || true
+}
+
+step "CUJ 6: Configure Solr Server ($MODULE)"
 
 if [ "$MODULE" = "apachesolr" ]; then
   SCHEMA_PATH="sites/all/modules/apachesolr/solr-conf/solr-9.x/schema.xml"
@@ -22,20 +28,19 @@ else
   exit 1
 fi
 
-echo "Posting schema: $SCHEMA_PATH"
+step "Step 1: Post Solr 9 schema ($SCHEMA_PATH)"
 
-# Post schema with retry (Solr endpoint can return 502 transiently)
 MAX_RETRIES=3
 RETRY_DELAY=60
 for attempt in $(seq 1 $MAX_RETRIES); do
   echo "Schema post attempt $attempt of $MAX_RETRIES..."
-  RESULT=$(terminus drush "$SITE_ENV" -- ev "
+  RESULT=$(drush_ev_extract "SCHEMA_" "
     variable_set('pantheon_apachesolr_schema', '$SCHEMA_PATH');
     \$result = pantheon_apachesolr_post_schema_exec('$SCHEMA_PATH');
     echo \$result ? 'SCHEMA_POSTED' : 'SCHEMA_FAILED';
-  " 2>&1) || true
+  ")
 
-  if echo "$RESULT" | grep -q "SCHEMA_POSTED"; then
+  if [ "$RESULT" = "SCHEMA_POSTED" ]; then
     echo "Schema posted successfully."
     break
   fi
@@ -44,16 +49,14 @@ for attempt in $(seq 1 $MAX_RETRIES); do
     echo "Schema post failed, retrying in ${RETRY_DELAY}s..."
     sleep "$RETRY_DELAY"
   else
-    echo "::error::Schema post failed after $MAX_RETRIES attempts"
-    echo "Last output: $RESULT"
+    echo "::error::Schema post failed after $MAX_RETRIES attempts. Result: $RESULT"
     exit 1
   fi
 done
 
-# Step 2: Verify ping
-echo "--- Step 2: Verify Solr ping ---"
+step "Step 2: Verify Solr ping"
 
-PING_RESULT=$(terminus drush "$SITE_ENV" -- ev "
+PING_RESULT=$(drush_ev_extract "PING_" "
   \$host = PANTHEON_APACHESOLR_HOST;
   \$path = getenv('PANTHEON_INDEX_PATH') . getenv('PANTHEON_INDEX_CORE') . '/admin/ping';
   if ('$MODULE' === 'search_api_solr') {
@@ -68,26 +71,24 @@ PING_RESULT=$(terminus drush "$SITE_ENV" -- ev "
   \$response = curl_exec(\$ch);
   \$info = curl_getinfo(\$ch);
   curl_close(\$ch);
-  if (\$response !== FALSE && in_array(\$info['http_code'], array(200, 201, 202, 204))) {
-    echo 'PING_OK';
-  } else {
-    echo 'PING_FAILED:' . \$info['http_code'];
-  }
-" 2>&1)
+  echo (\$response !== FALSE && in_array(\$info['http_code'], array(200, 201, 202, 204))) ? 'PING_OK' : 'PING_FAILED:' . \$info['http_code'];
+")
 
-if echo "$PING_RESULT" | grep -q "PING_OK"; then
+if [ "$PING_RESULT" = "PING_OK" ]; then
   echo "Solr ping successful."
 else
   echo "::error::Solr ping failed: $PING_RESULT"
   exit 1
 fi
 
-# Step 3: Module-specific server verification
-echo "--- Step 3: Module-specific verification ---"
+step "Step 3: Module-specific verification"
+
+# Get Solr version for reporting
+SOLR_VER=$(drush_ev_extract "SOLR_VER:" "echo 'SOLR_VER:' . (isset(\$_ENV['search_version']) ? \$_ENV['search_version'] : 'unknown');")
+SOLR_VER="${SOLR_VER#SOLR_VER:}"
 
 if [ "$MODULE" = "apachesolr" ]; then
-  # Apache Solr Search auto-configures. Verify default environment exists.
-  ENV_CHECK=$(terminus drush "$SITE_ENV" -- ev "
+  ENV_URL=$(drush_ev_extract "ENV_OK:" "
     \$env_id = apachesolr_default_environment();
     if (\$env_id) {
       \$env = apachesolr_environment_load(\$env_id);
@@ -95,20 +96,19 @@ if [ "$MODULE" = "apachesolr" ]; then
     } else {
       echo 'ENV_MISSING';
     }
-  " 2>&1)
+  ")
 
-  if echo "$ENV_CHECK" | grep -q "ENV_OK"; then
-    echo "Apache Solr default environment configured: $ENV_CHECK"
+  if echo "$ENV_URL" | grep -q "ENV_OK:"; then
+    echo "Apache Solr default environment configured (Solr $SOLR_VER)."
+    echo "URL: ${ENV_URL#ENV_OK:}"
   else
-    echo "::error::Apache Solr default environment not found: $ENV_CHECK"
+    echo "::error::Apache Solr default environment not found"
     exit 1
   fi
 
 elif [ "$MODULE" = "search_api_solr" ]; then
-  # Search API Solr needs a server created programmatically
-  # Service class is search_api_solr_service (Pantheon overrides it internally)
   echo "Creating Search API server..."
-  SERVER_RESULT=$(terminus drush "$SITE_ENV" -- ev "
+  SERVER_RESULT=$(drush_ev_extract "SERVER_" "
     \$server = entity_create('search_api_server', array(
       'name' => 'Pantheon Solr 9',
       'machine_name' => 'pantheon_solr9',
@@ -119,31 +119,26 @@ elif [ "$MODULE" = "search_api_solr" ]; then
     ));
     \$server->save();
     echo \$server->machine_name ? 'SERVER_CREATED' : 'SERVER_FAILED';
-  " 2>&1)
+  ")
 
-  if echo "$SERVER_RESULT" | grep -q "SERVER_CREATED"; then
+  if [ "$SERVER_RESULT" = "SERVER_CREATED" ]; then
     echo "Search API server created."
   else
     echo "::error::Failed to create Search API server: $SERVER_RESULT"
     exit 1
   fi
 
-  # Verify server status
-  STATUS=$(terminus drush "$SITE_ENV" -- ev "
+  STATUS=$(drush_ev_extract "SERVER_" "
     \$server = search_api_server_load('pantheon_solr9');
-    if (\$server && \$server->ping()) {
-      echo 'SERVER_CONNECTED';
-    } else {
-      echo 'SERVER_DISCONNECTED';
-    }
-  " 2>&1)
+    echo (\$server && \$server->ping()) ? 'SERVER_CONNECTED' : 'SERVER_DISCONNECTED';
+  ")
 
-  if echo "$STATUS" | grep -q "SERVER_CONNECTED"; then
-    echo "Search API server connected to Solr 9."
+  if [ "$STATUS" = "SERVER_CONNECTED" ]; then
+    echo "Search API server connected (Solr $SOLR_VER)."
   else
     echo "::error::Search API server not connected: $STATUS"
     exit 1
   fi
 fi
 
-echo "=== CUJ 6 PASSED: $MODULE configured and connected to Solr 9 ==="
+step "CUJ 6 PASSED: $MODULE configured and connected to Solr $SOLR_VER"

--- a/.github/scripts/solr9-cuj6-configure-server.sh
+++ b/.github/scripts/solr9-cuj6-configure-server.sh
@@ -1,0 +1,143 @@
+#!/bin/bash
+set -euo pipefail
+
+# CUJ 6: Configure a Solr Server
+# Tests that the search module can connect to Solr 9 after schema posting.
+# Accepts MODULE env var: apachesolr or search_api_solr
+
+SITE_ENV="${TERMINUS_SITE}.${MULTIDEV}"
+MODULE="${MODULE:?MODULE env var must be set}"
+
+echo "=== CUJ 6: Configure Solr Server ($MODULE) ==="
+
+# Step 1: Post Solr 9 schema
+echo "--- Step 1: Post Solr 9 schema ---"
+
+if [ "$MODULE" = "apachesolr" ]; then
+  SCHEMA_PATH="sites/all/modules/apachesolr/solr-conf/solr-9.x/schema.xml"
+elif [ "$MODULE" = "search_api_solr" ]; then
+  SCHEMA_PATH="sites/all/modules/search_api_solr/solr-conf/9.x/schema.xml"
+else
+  echo "::error::Unknown module: $MODULE"
+  exit 1
+fi
+
+echo "Posting schema: $SCHEMA_PATH"
+
+# Post schema with retry (Solr endpoint can return 502 transiently)
+MAX_RETRIES=3
+RETRY_DELAY=60
+for attempt in $(seq 1 $MAX_RETRIES); do
+  echo "Schema post attempt $attempt of $MAX_RETRIES..."
+  RESULT=$(terminus drush "$SITE_ENV" -- ev "
+    variable_set('pantheon_apachesolr_schema', '$SCHEMA_PATH');
+    \$result = pantheon_apachesolr_post_schema_exec('$SCHEMA_PATH');
+    echo \$result ? 'SCHEMA_POSTED' : 'SCHEMA_FAILED';
+  " 2>&1) || true
+
+  if echo "$RESULT" | grep -q "SCHEMA_POSTED"; then
+    echo "Schema posted successfully."
+    break
+  fi
+
+  if [ "$attempt" -lt "$MAX_RETRIES" ]; then
+    echo "Schema post failed, retrying in ${RETRY_DELAY}s..."
+    sleep "$RETRY_DELAY"
+  else
+    echo "::error::Schema post failed after $MAX_RETRIES attempts"
+    echo "Last output: $RESULT"
+    exit 1
+  fi
+done
+
+# Step 2: Verify ping
+echo "--- Step 2: Verify Solr ping ---"
+
+PING_RESULT=$(terminus drush "$SITE_ENV" -- ev "
+  \$host = PANTHEON_APACHESOLR_HOST;
+  \$path = getenv('PANTHEON_INDEX_PATH') . getenv('PANTHEON_INDEX_CORE') . '/admin/ping';
+  if ('$MODULE' === 'search_api_solr') {
+    \$path .= '?q=id:1';
+  }
+  \$url = 'https://' . \$host . '/' . \$path;
+  list(\$ch, \$opts) = pantheon_apachesolr_curl_setup(\$url, PANTHEON_APACHESOLR_PORT);
+  \$opts = pantheon_apachesolr_curlopts(\$opts);
+  \$opts[CURLOPT_CONNECTTIMEOUT] = 5;
+  \$opts[CURLOPT_RETURNTRANSFER] = 1;
+  curl_setopt_array(\$ch, \$opts);
+  \$response = curl_exec(\$ch);
+  \$info = curl_getinfo(\$ch);
+  curl_close(\$ch);
+  if (\$response !== FALSE && in_array(\$info['http_code'], array(200, 201, 202, 204))) {
+    echo 'PING_OK';
+  } else {
+    echo 'PING_FAILED:' . \$info['http_code'];
+  }
+" 2>&1)
+
+if echo "$PING_RESULT" | grep -q "PING_OK"; then
+  echo "Solr ping successful."
+else
+  echo "::error::Solr ping failed: $PING_RESULT"
+  exit 1
+fi
+
+# Step 3: Module-specific server verification
+echo "--- Step 3: Module-specific verification ---"
+
+if [ "$MODULE" = "apachesolr" ]; then
+  # Apache Solr Search auto-configures. Verify default environment exists.
+  ENV_CHECK=$(terminus drush "$SITE_ENV" -- ev "
+    \$env = apachesolr_default_environment();
+    echo \$env ? 'ENV_OK:' . \$env['url'] : 'ENV_MISSING';
+  " 2>&1)
+
+  if echo "$ENV_CHECK" | grep -q "ENV_OK"; then
+    echo "Apache Solr default environment configured: $ENV_CHECK"
+  else
+    echo "::error::Apache Solr default environment not found: $ENV_CHECK"
+    exit 1
+  fi
+
+elif [ "$MODULE" = "search_api_solr" ]; then
+  # Search API Solr needs a server created programmatically
+  echo "Creating Search API server..."
+  SERVER_RESULT=$(terminus drush "$SITE_ENV" -- ev "
+    \$server = entity_create('search_api_server', array(
+      'name' => 'Pantheon Solr 9',
+      'machine_name' => 'pantheon_solr9',
+      'class' => 'PantheonApachesolrSearchApiSolrService',
+      'enabled' => 1,
+      'description' => 'Solr 9 server on Pantheon',
+      'options' => array('clean_ids' => TRUE),
+    ));
+    \$server->save();
+    echo \$server->machine_name ? 'SERVER_CREATED' : 'SERVER_FAILED';
+  " 2>&1)
+
+  if echo "$SERVER_RESULT" | grep -q "SERVER_CREATED"; then
+    echo "Search API server created."
+  else
+    echo "::error::Failed to create Search API server: $SERVER_RESULT"
+    exit 1
+  fi
+
+  # Verify server status
+  STATUS=$(terminus drush "$SITE_ENV" -- ev "
+    \$server = search_api_server_load('pantheon_solr9');
+    if (\$server && \$server->ping()) {
+      echo 'SERVER_CONNECTED';
+    } else {
+      echo 'SERVER_DISCONNECTED';
+    }
+  " 2>&1)
+
+  if echo "$STATUS" | grep -q "SERVER_CONNECTED"; then
+    echo "Search API server connected to Solr 9."
+  else
+    echo "::error::Search API server not connected: $STATUS"
+    exit 1
+  fi
+fi
+
+echo "=== CUJ 6 PASSED: $MODULE configured and connected to Solr 9 ==="

--- a/.github/scripts/solr9-cuj6-configure-server.sh
+++ b/.github/scripts/solr9-cuj6-configure-server.sh
@@ -12,7 +12,7 @@ step() { echo ""; echo ">>>>>>>>>> $1 <<<<<<<<<<"; echo ""; }
 
 # Helper: run drush ev, suppress terminus stderr noise, return clean stdout
 drush_ev() {
-  terminus drush "$SITE_ENV" -- ev "$@" 2>/dev/null | tail -1 | tr -d '[:space:]'
+  terminus drush "$SITE_ENV" -- ev "$@" 2>&1 | grep -v "^\[warning\]\|^\[notice\]\|^\[error\]\|^Warning:\|^Notice:\|^Command:\|drush.in\|Exit:" | tail -1 | tr -d '[:space:]'
 }
 
 step "CUJ 6: Configure Solr Server ($MODULE)"

--- a/.github/scripts/solr9-cuj6-configure-server.sh
+++ b/.github/scripts/solr9-cuj6-configure-server.sh
@@ -10,9 +10,8 @@ MODULE="${MODULE:?MODULE env var must be set}"
 
 step() { echo ""; echo ">>>>>>>>>> $1 <<<<<<<<<<"; echo ""; }
 
-# Helper: run drush ev, suppress terminus stderr noise, return clean stdout
 drush_ev() {
-  terminus drush "$SITE_ENV" -- ev "$@" 2>&1 | grep -v "^\[warning\]\|^\[notice\]\|^\[error\]\|^Warning:\|^Notice:\|^Command:\|drush.in\|Exit:" | tail -1 | tr -d '[:space:]'
+  terminus drush "$SITE_ENV" -- ev "$@" 2>&1
 }
 
 step "CUJ 6: Configure Solr Server ($MODULE)"
@@ -36,9 +35,9 @@ for attempt in $(seq 1 $MAX_RETRIES); do
     variable_set('pantheon_apachesolr_schema', '$SCHEMA_PATH');
     \$result = pantheon_apachesolr_post_schema_exec('$SCHEMA_PATH');
     echo \$result ? 'SCHEMA_POSTED' : 'SCHEMA_FAILED';
-  ")
+  ") || true
 
-  if [ "$RESULT" = "SCHEMA_POSTED" ]; then
+  if echo "$RESULT" | grep -q "SCHEMA_POSTED"; then
     echo "Schema posted successfully."
     break
   fi
@@ -47,7 +46,7 @@ for attempt in $(seq 1 $MAX_RETRIES); do
     echo "Schema post failed, retrying in ${RETRY_DELAY}s..."
     sleep "$RETRY_DELAY"
   else
-    echo "::error::Schema post failed after $MAX_RETRIES attempts. Result: $RESULT"
+    echo "::error::Schema post failed after $MAX_RETRIES attempts."
     exit 1
   fi
 done
@@ -70,9 +69,9 @@ PING_RESULT=$(drush_ev "
   \$info = curl_getinfo(\$ch);
   curl_close(\$ch);
   echo (\$response !== FALSE && in_array(\$info['http_code'], array(200, 201, 202, 204))) ? 'PING_OK' : 'PING_FAILED:' . \$info['http_code'];
-")
+") || true
 
-if [ "$PING_RESULT" = "PING_OK" ]; then
+if echo "$PING_RESULT" | grep -q "PING_OK"; then
   echo "Solr ping successful."
 else
   echo "::error::Solr ping failed: $PING_RESULT"
@@ -81,23 +80,19 @@ fi
 
 step "Step 3: Module-specific verification"
 
-# Get Solr version for reporting
-SOLR_VER=$(drush_ev "echo \$_ENV['search_version'] ?? 'unknown';")
-
 if [ "$MODULE" = "apachesolr" ]; then
-  ENV_URL=$(drush_ev "
+  ENV_CHECK=$(drush_ev "
     \$env_id = apachesolr_default_environment();
     if (\$env_id) {
       \$env = apachesolr_environment_load(\$env_id);
-      echo \$env['url'];
+      echo 'ENV_OK:' . \$env['url'];
     } else {
       echo 'ENV_MISSING';
     }
-  ")
+  ") || true
 
-  if [ "$ENV_URL" != "ENV_MISSING" ] && [ -n "$ENV_URL" ]; then
-    echo "Apache Solr default environment configured (Solr $SOLR_VER)."
-    echo "URL: $ENV_URL"
+  if echo "$ENV_CHECK" | grep -q "ENV_OK"; then
+    echo "Apache Solr default environment configured."
   else
     echo "::error::Apache Solr default environment not found"
     exit 1
@@ -116,26 +111,26 @@ elif [ "$MODULE" = "search_api_solr" ]; then
     ));
     \$server->save();
     echo \$server->machine_name ? 'SERVER_CREATED' : 'SERVER_FAILED';
-  ")
+  ") || true
 
-  if [ "$SERVER_RESULT" = "SERVER_CREATED" ]; then
+  if echo "$SERVER_RESULT" | grep -q "SERVER_CREATED"; then
     echo "Search API server created."
   else
-    echo "::error::Failed to create Search API server: $SERVER_RESULT"
+    echo "::error::Failed to create Search API server"
     exit 1
   fi
 
   STATUS=$(drush_ev "
     \$server = search_api_server_load('pantheon_solr9');
     echo (\$server && \$server->ping()) ? 'SERVER_CONNECTED' : 'SERVER_DISCONNECTED';
-  ")
+  ") || true
 
-  if [ "$STATUS" = "SERVER_CONNECTED" ]; then
-    echo "Search API server connected (Solr $SOLR_VER)."
+  if echo "$STATUS" | grep -q "SERVER_CONNECTED"; then
+    echo "Search API server connected."
   else
-    echo "::error::Search API server not connected: $STATUS"
+    echo "::error::Search API server not connected"
     exit 1
   fi
 fi
 
-step "CUJ 6 PASSED: $MODULE configured and connected to Solr $SOLR_VER"
+step "CUJ 6 PASSED: $MODULE configured and connected to Solr 9"

--- a/.github/scripts/solr9-cuj7-create-index.sh
+++ b/.github/scripts/solr9-cuj7-create-index.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+set -euo pipefail
+
+# CUJ 7: Create and Configure a Search Index
+# Tests that content can be indexed into Solr 9.
+# Accepts MODULE env var: apachesolr or search_api_solr
+
+SITE_ENV="${TERMINUS_SITE}.${MULTIDEV}"
+MODULE="${MODULE:?MODULE env var must be set}"
+
+echo "=== CUJ 7: Create and Configure Search Index ($MODULE) ==="
+
+if [ "$MODULE" = "apachesolr" ]; then
+  # Apache Solr Search: no explicit index creation needed.
+  # Mark all content for reindexing and run indexer.
+
+  echo "--- Step 1: Mark all content for reindexing ---"
+  terminus drush "$SITE_ENV" -- solr-mark-all
+
+  echo "--- Step 2: Index content ---"
+  terminus drush "$SITE_ENV" -- solr-index
+
+  echo "--- Step 3: Verify index count ---"
+  INDEX_STATS=$(terminus drush "$SITE_ENV" -- ev "
+    \$env_id = apachesolr_default_environment();
+    \$env = apachesolr_environment_load(\$env_id);
+    try {
+      \$solr = apachesolr_get_solr(\$env_id);
+      \$response = \$solr->getLuke();
+      echo 'INDEX_COUNT:' . \$response->index->numDocs;
+    } catch (Exception \$e) {
+      echo 'INDEX_ERROR:' . \$e->getMessage();
+    }
+  " 2>&1)
+
+  if echo "$INDEX_STATS" | grep -q "INDEX_COUNT:"; then
+    COUNT=$(echo "$INDEX_STATS" | grep -o 'INDEX_COUNT:[0-9]*' | cut -d: -f2)
+    if [ "$COUNT" -gt 0 ]; then
+      echo "Index contains $COUNT documents."
+    else
+      echo "::error::Index is empty after indexing"
+      exit 1
+    fi
+  else
+    echo "::error::Failed to get index stats: $INDEX_STATS"
+    exit 1
+  fi
+
+elif [ "$MODULE" = "search_api_solr" ]; then
+  # Search API Solr: create index, add fields, index content.
+
+  echo "--- Step 1: Create Search API index ---"
+  INDEX_RESULT=$(terminus drush "$SITE_ENV" -- ev "
+    \$index = entity_create('search_api_index', array(
+      'name' => 'Site Content',
+      'machine_name' => 'site_content',
+      'server' => 'pantheon_solr9',
+      'item_type' => 'node',
+      'enabled' => 1,
+      'options' => array(
+        'index_directly' => 1,
+        'fields' => array(
+          'title' => array('type' => 'text'),
+          'body:value' => array('type' => 'text'),
+          'type' => array('type' => 'string'),
+          'status' => array('type' => 'boolean'),
+        ),
+      ),
+    ));
+    \$index->save();
+    echo \$index->machine_name ? 'INDEX_CREATED' : 'INDEX_FAILED';
+  " 2>&1)
+
+  if echo "$INDEX_RESULT" | grep -q "INDEX_CREATED"; then
+    echo "Search API index created."
+  else
+    echo "::error::Failed to create Search API index: $INDEX_RESULT"
+    exit 1
+  fi
+
+  echo "--- Step 2: Index content ---"
+  terminus drush "$SITE_ENV" -- search-api-index site_content
+
+  echo "--- Step 3: Verify index status ---"
+  STATUS=$(terminus drush "$SITE_ENV" -- search-api-status site_content 2>&1)
+  echo "$STATUS"
+
+  if echo "$STATUS" | grep -q "100%"; then
+    echo "Index is 100% complete."
+  else
+    # Check if items were indexed even if not 100%
+    INDEXED=$(echo "$STATUS" | grep -o 'Indexed[[:space:]]*[0-9]*' | grep -o '[0-9]*')
+    if [ -n "$INDEXED" ] && [ "$INDEXED" -gt 0 ]; then
+      echo "Warning: Index not 100% but $INDEXED items indexed."
+    else
+      echo "::error::No items indexed: $STATUS"
+      exit 1
+    fi
+  fi
+
+else
+  echo "::error::Unknown module: $MODULE"
+  exit 1
+fi
+
+echo "=== CUJ 7 PASSED: $MODULE index created and content indexed ==="

--- a/.github/scripts/solr9-cuj7-create-index.sh
+++ b/.github/scripts/solr9-cuj7-create-index.sh
@@ -11,7 +11,7 @@ MODULE="${MODULE:?MODULE env var must be set}"
 step() { echo ""; echo ">>>>>>>>>> $1 <<<<<<<<<<"; echo ""; }
 
 drush_ev() {
-  terminus drush "$SITE_ENV" -- ev "$@" 2>/dev/null | tail -1 | tr -d '[:space:]'
+  terminus drush "$SITE_ENV" -- ev "$@" 2>&1 | grep -v "^\[warning\]\|^\[notice\]\|^\[error\]\|^Warning:\|^Notice:\|^Command:\|drush.in\|Exit:" | tail -1 | tr -d '[:space:]'
 }
 
 step "CUJ 7: Create and Configure Search Index ($MODULE)"

--- a/.github/scripts/solr9-cuj7-create-index.sh
+++ b/.github/scripts/solr9-cuj7-create-index.sh
@@ -30,15 +30,7 @@ if [ "$MODULE" = "apachesolr" ]; then
   step "Step 2: Index content"
   terminus drush "$SITE_ENV" -- solr-index
 
-  step "Step 3: Commit index and verify count"
-  # Force Solr commit to ensure docs are searchable before CUJ 8
-  drush_ev "
-    \$env_id = apachesolr_default_environment();
-    \$solr = apachesolr_get_solr(\$env_id);
-    \$solr->commit();
-  " || true
-  sleep 5
-
+  step "Step 3: Verify index count"
   INDEX_STATS=$(drush_ev "
     \$env_id = apachesolr_default_environment();
     try {

--- a/.github/scripts/solr9-cuj7-create-index.sh
+++ b/.github/scripts/solr9-cuj7-create-index.sh
@@ -11,7 +11,7 @@ MODULE="${MODULE:?MODULE env var must be set}"
 step() { echo ""; echo ">>>>>>>>>> $1 <<<<<<<<<<"; echo ""; }
 
 drush_ev() {
-  terminus drush "$SITE_ENV" -- ev "$@" 2>&1 | grep -v "^\[warning\]\|^\[notice\]\|^\[error\]\|^Warning:\|^Notice:\|^Command:\|drush.in\|Exit:" | tail -1 | tr -d '[:space:]'
+  terminus drush "$SITE_ENV" -- ev "$@" 2>&1
 }
 
 step "CUJ 7: Create and Configure Search Index ($MODULE)"
@@ -19,12 +19,11 @@ step "CUJ 7: Create and Configure Search Index ($MODULE)"
 if [ "$MODULE" = "apachesolr" ]; then
 
   step "Step 1: Configure indexing and mark content"
-  # apachesolr needs entity types and bundles configured before indexing
   drush_ev "
     \$env_id = apachesolr_default_environment();
     module_load_include('inc', 'apachesolr', 'apachesolr.index');
     apachesolr_index_set_bundles(\$env_id, 'node', array('article', 'page'));
-  "
+  " || true
   echo "Configured article and page bundles for indexing."
   terminus drush "$SITE_ENV" -- solr-mark-all
 
@@ -32,21 +31,27 @@ if [ "$MODULE" = "apachesolr" ]; then
   terminus drush "$SITE_ENV" -- solr-index
 
   step "Step 3: Verify index count"
-  COUNT=$(drush_ev "
+  INDEX_STATS=$(drush_ev "
     \$env_id = apachesolr_default_environment();
     try {
       \$solr = apachesolr_get_solr(\$env_id);
       \$response = \$solr->getLuke();
-      echo \$response->index->numDocs;
+      echo 'INDEX_COUNT:' . \$response->index->numDocs;
     } catch (Exception \$e) {
-      echo '0';
+      echo 'INDEX_ERROR:' . \$e->getMessage();
     }
-  ")
+  ") || true
 
-  if [ -n "$COUNT" ] && [ "$COUNT" -gt 0 ] 2>/dev/null; then
-    echo "Index contains $COUNT documents."
+  if echo "$INDEX_STATS" | grep -q "INDEX_COUNT:"; then
+    COUNT=$(echo "$INDEX_STATS" | grep -o 'INDEX_COUNT:[0-9]*' | head -1 | cut -d: -f2)
+    if [ -n "$COUNT" ] && [ "$COUNT" -gt 0 ] 2>/dev/null; then
+      echo "Index contains $COUNT documents."
+    else
+      echo "::error::Index is empty after indexing"
+      exit 1
+    fi
   else
-    echo "::error::Index is empty or count failed: $COUNT"
+    echo "::error::Failed to get index stats"
     exit 1
   fi
 
@@ -72,12 +77,12 @@ elif [ "$MODULE" = "search_api_solr" ]; then
     ));
     \$index->save();
     echo \$index->machine_name ? 'INDEX_CREATED' : 'INDEX_FAILED';
-  ")
+  ") || true
 
-  if [ "$INDEX_RESULT" = "INDEX_CREATED" ]; then
+  if echo "$INDEX_RESULT" | grep -q "INDEX_CREATED"; then
     echo "Search API index created."
   else
-    echo "::error::Failed to create Search API index: $INDEX_RESULT"
+    echo "::error::Failed to create Search API index"
     exit 1
   fi
 
@@ -85,19 +90,18 @@ elif [ "$MODULE" = "search_api_solr" ]; then
   terminus drush "$SITE_ENV" -- search-api-index site_content
 
   step "Step 3: Verify index status"
-  terminus drush "$SITE_ENV" -- search-api-status site_content
+  STATUS=$(terminus drush "$SITE_ENV" -- search-api-status site_content 2>&1)
+  echo "$STATUS"
 
-  INDEXED=$(drush_ev "
-    \$index = search_api_index_load('site_content');
-    \$status = search_api_index_status(\$index);
-    echo \$status['indexed'];
-  ")
-
-  if [ -n "$INDEXED" ] && [ "$INDEXED" -gt 0 ] 2>/dev/null; then
-    echo "Indexed $INDEXED items."
+  if echo "$STATUS" | grep -q "100%"; then
+    echo "Index is 100% complete."
   else
-    echo "::error::No items indexed: $INDEXED"
-    exit 1
+    if echo "$STATUS" | grep -qE "Indexed.*[1-9]"; then
+      echo "Warning: Index not 100% but items were indexed."
+    else
+      echo "::error::No items indexed"
+      exit 1
+    fi
   fi
 
 else

--- a/.github/scripts/solr9-cuj7-create-index.sh
+++ b/.github/scripts/solr9-cuj7-create-index.sh
@@ -11,14 +11,21 @@ MODULE="${MODULE:?MODULE env var must be set}"
 step() { echo ""; echo ">>>>>>>>>> $1 <<<<<<<<<<"; echo ""; }
 
 drush_ev() {
-  terminus drush "$SITE_ENV" -- ev "$@" 2>/dev/null | tr -d '[:space:]'
+  terminus drush "$SITE_ENV" -- ev "$@" 2>/dev/null | tail -1 | tr -d '[:space:]'
 }
 
 step "CUJ 7: Create and Configure Search Index ($MODULE)"
 
 if [ "$MODULE" = "apachesolr" ]; then
 
-  step "Step 1: Mark all content for reindexing"
+  step "Step 1: Configure indexing and mark content"
+  # apachesolr needs entity types and bundles configured before indexing
+  drush_ev "
+    \$env_id = apachesolr_default_environment();
+    module_load_include('inc', 'apachesolr', 'apachesolr.index');
+    apachesolr_index_set_bundles(\$env_id, 'node', array('article', 'page'));
+  "
+  echo "Configured article and page bundles for indexing."
   terminus drush "$SITE_ENV" -- solr-mark-all
 
   step "Step 2: Index content"

--- a/.github/scripts/solr9-cuj7-create-index.sh
+++ b/.github/scripts/solr9-cuj7-create-index.sh
@@ -8,22 +8,27 @@ set -euo pipefail
 SITE_ENV="${TERMINUS_SITE}.${MULTIDEV}"
 MODULE="${MODULE:?MODULE env var must be set}"
 
-echo "=== CUJ 7: Create and Configure Search Index ($MODULE) ==="
+step() { echo ""; echo ">>>>>>>>>> $1 <<<<<<<<<<"; echo ""; }
+
+drush_ev_extract() {
+  local pattern="$1"
+  shift
+  terminus drush "$SITE_ENV" -- ev "$@" 2>&1 | grep -o "${pattern}[^ ]*" || true
+}
+
+step "CUJ 7: Create and Configure Search Index ($MODULE)"
 
 if [ "$MODULE" = "apachesolr" ]; then
-  # Apache Solr Search: no explicit index creation needed.
-  # Mark all content for reindexing and run indexer.
 
-  echo "--- Step 1: Mark all content for reindexing ---"
+  step "Step 1: Mark all content for reindexing"
   terminus drush "$SITE_ENV" -- solr-mark-all
 
-  echo "--- Step 2: Index content ---"
+  step "Step 2: Index content"
   terminus drush "$SITE_ENV" -- solr-index
 
-  echo "--- Step 3: Verify index count ---"
-  INDEX_STATS=$(terminus drush "$SITE_ENV" -- ev "
+  step "Step 3: Verify index count"
+  COUNT=$(drush_ev_extract "INDEX_COUNT:" "
     \$env_id = apachesolr_default_environment();
-    \$env = apachesolr_environment_load(\$env_id);
     try {
       \$solr = apachesolr_get_solr(\$env_id);
       \$response = \$solr->getLuke();
@@ -31,26 +36,20 @@ if [ "$MODULE" = "apachesolr" ]; then
     } catch (Exception \$e) {
       echo 'INDEX_ERROR:' . \$e->getMessage();
     }
-  " 2>&1)
+  ")
+  COUNT="${COUNT#INDEX_COUNT:}"
 
-  if echo "$INDEX_STATS" | grep -q "INDEX_COUNT:"; then
-    COUNT=$(echo "$INDEX_STATS" | grep -o 'INDEX_COUNT:[0-9]*' | cut -d: -f2)
-    if [ "$COUNT" -gt 0 ]; then
-      echo "Index contains $COUNT documents."
-    else
-      echo "::error::Index is empty after indexing"
-      exit 1
-    fi
+  if [ -n "$COUNT" ] && [ "$COUNT" -gt 0 ] 2>/dev/null; then
+    echo "Index contains $COUNT documents."
   else
-    echo "::error::Failed to get index stats: $INDEX_STATS"
+    echo "::error::Index is empty or count failed: $COUNT"
     exit 1
   fi
 
 elif [ "$MODULE" = "search_api_solr" ]; then
-  # Search API Solr: create index, add fields, index content.
 
-  echo "--- Step 1: Create Search API index ---"
-  INDEX_RESULT=$(terminus drush "$SITE_ENV" -- ev "
+  step "Step 1: Create Search API index"
+  INDEX_RESULT=$(drush_ev_extract "INDEX_" "
     \$index = entity_create('search_api_index', array(
       'name' => 'Site Content',
       'machine_name' => 'site_content',
@@ -69,26 +68,25 @@ elif [ "$MODULE" = "search_api_solr" ]; then
     ));
     \$index->save();
     echo \$index->machine_name ? 'INDEX_CREATED' : 'INDEX_FAILED';
-  " 2>&1)
+  ")
 
-  if echo "$INDEX_RESULT" | grep -q "INDEX_CREATED"; then
+  if [ "$INDEX_RESULT" = "INDEX_CREATED" ]; then
     echo "Search API index created."
   else
     echo "::error::Failed to create Search API index: $INDEX_RESULT"
     exit 1
   fi
 
-  echo "--- Step 2: Index content ---"
+  step "Step 2: Index content"
   terminus drush "$SITE_ENV" -- search-api-index site_content
 
-  echo "--- Step 3: Verify index status ---"
+  step "Step 3: Verify index status"
   STATUS=$(terminus drush "$SITE_ENV" -- search-api-status site_content 2>&1)
   echo "$STATUS"
 
   if echo "$STATUS" | grep -q "100%"; then
     echo "Index is 100% complete."
   else
-    # Check if items were indexed even if not 100%
     INDEXED=$(echo "$STATUS" | grep -o 'Indexed[[:space:]]*[0-9]*' | grep -o '[0-9]*')
     if [ -n "$INDEXED" ] && [ "$INDEXED" -gt 0 ]; then
       echo "Warning: Index not 100% but $INDEXED items indexed."
@@ -103,4 +101,4 @@ else
   exit 1
 fi
 
-echo "=== CUJ 7 PASSED: $MODULE index created and content indexed ==="
+step "CUJ 7 PASSED: $MODULE index created and content indexed"

--- a/.github/scripts/solr9-cuj7-create-index.sh
+++ b/.github/scripts/solr9-cuj7-create-index.sh
@@ -30,28 +30,17 @@ if [ "$MODULE" = "apachesolr" ]; then
   step "Step 2: Index content"
   terminus drush "$SITE_ENV" -- solr-index
 
-  step "Step 3: Verify index count"
-  INDEX_STATS=$(drush_ev "
-    \$env_id = apachesolr_default_environment();
-    try {
-      \$solr = apachesolr_get_solr(\$env_id);
-      \$response = \$solr->getLuke();
-      echo 'INDEX_COUNT:' . \$response->index->numDocs . ' ';
-    } catch (Exception \$e) {
-      echo 'INDEX_ERROR:' . \$e->getMessage();
-    }
+  step "Step 3: Verify index via search"
+  VERIFY=$(drush_ev "
+    \$results = node_search_execute('Solr');
+    echo 'VERIFY_COUNT:' . count(\$results) . ' ';
   ") || true
 
-  if echo "$INDEX_STATS" | grep -q "INDEX_COUNT:"; then
-    COUNT=$(echo "$INDEX_STATS" | grep -o 'INDEX_COUNT:[0-9]*' | head -1 | cut -d: -f2)
-    if [ -n "$COUNT" ] && [ "$COUNT" -gt 0 ] 2>/dev/null; then
-      echo "Index contains $COUNT documents."
-    else
-      echo "::error::Index is empty after indexing"
-      exit 1
-    fi
+  if echo "$VERIFY" | grep -qE "VERIFY_COUNT:[1-9]"; then
+    COUNT=$(echo "$VERIFY" | grep -o 'VERIFY_COUNT:[0-9]*' | head -1 | cut -d: -f2)
+    echo "Search verification: $COUNT results for 'Solr'."
   else
-    echo "::error::Failed to get index stats"
+    echo "::error::Index verification failed: search returned 0 results after indexing"
     exit 1
   fi
 

--- a/.github/scripts/solr9-cuj7-create-index.sh
+++ b/.github/scripts/solr9-cuj7-create-index.sh
@@ -8,11 +8,8 @@ set -euo pipefail
 SITE_ENV="${TERMINUS_SITE}.${MULTIDEV}"
 MODULE="${MODULE:?MODULE env var must be set}"
 
-step() { echo ""; echo ">>>>>>>>>> $1 <<<<<<<<<<"; echo ""; }
-
-drush_ev() {
-  terminus drush "$SITE_ENV" -- ev "$@" 2>&1
-}
+# shellcheck source=.github/scripts/solr9-shared.sh
+source "$(dirname "$0")/solr9-shared.sh"
 
 step "CUJ 7: Create and Configure Search Index ($MODULE)"
 

--- a/.github/scripts/solr9-cuj7-create-index.sh
+++ b/.github/scripts/solr9-cuj7-create-index.sh
@@ -44,7 +44,7 @@ if [ "$MODULE" = "apachesolr" ]; then
     try {
       \$solr = apachesolr_get_solr(\$env_id);
       \$response = \$solr->getLuke();
-      echo 'INDEX_COUNT:' . \$response->index->numDocs;
+      echo 'INDEX_COUNT:' . \$response->index->numDocs . ' ';
     } catch (Exception \$e) {
       echo 'INDEX_ERROR:' . \$e->getMessage();
     }

--- a/.github/scripts/solr9-cuj7-create-index.sh
+++ b/.github/scripts/solr9-cuj7-create-index.sh
@@ -10,10 +10,8 @@ MODULE="${MODULE:?MODULE env var must be set}"
 
 step() { echo ""; echo ">>>>>>>>>> $1 <<<<<<<<<<"; echo ""; }
 
-drush_ev_extract() {
-  local pattern="$1"
-  shift
-  terminus drush "$SITE_ENV" -- ev "$@" 2>&1 | grep -o "${pattern}[^ ]*" || true
+drush_ev() {
+  terminus drush "$SITE_ENV" -- ev "$@" 2>/dev/null | tr -d '[:space:]'
 }
 
 step "CUJ 7: Create and Configure Search Index ($MODULE)"
@@ -27,17 +25,16 @@ if [ "$MODULE" = "apachesolr" ]; then
   terminus drush "$SITE_ENV" -- solr-index
 
   step "Step 3: Verify index count"
-  COUNT=$(drush_ev_extract "INDEX_COUNT:" "
+  COUNT=$(drush_ev "
     \$env_id = apachesolr_default_environment();
     try {
       \$solr = apachesolr_get_solr(\$env_id);
       \$response = \$solr->getLuke();
-      echo 'INDEX_COUNT:' . \$response->index->numDocs;
+      echo \$response->index->numDocs;
     } catch (Exception \$e) {
-      echo 'INDEX_ERROR:' . \$e->getMessage();
+      echo '0';
     }
   ")
-  COUNT="${COUNT#INDEX_COUNT:}"
 
   if [ -n "$COUNT" ] && [ "$COUNT" -gt 0 ] 2>/dev/null; then
     echo "Index contains $COUNT documents."
@@ -49,7 +46,7 @@ if [ "$MODULE" = "apachesolr" ]; then
 elif [ "$MODULE" = "search_api_solr" ]; then
 
   step "Step 1: Create Search API index"
-  INDEX_RESULT=$(drush_ev_extract "INDEX_" "
+  INDEX_RESULT=$(drush_ev "
     \$index = entity_create('search_api_index', array(
       'name' => 'Site Content',
       'machine_name' => 'site_content',
@@ -81,19 +78,19 @@ elif [ "$MODULE" = "search_api_solr" ]; then
   terminus drush "$SITE_ENV" -- search-api-index site_content
 
   step "Step 3: Verify index status"
-  STATUS=$(terminus drush "$SITE_ENV" -- search-api-status site_content 2>&1)
-  echo "$STATUS"
+  terminus drush "$SITE_ENV" -- search-api-status site_content
 
-  if echo "$STATUS" | grep -q "100%"; then
-    echo "Index is 100% complete."
+  INDEXED=$(drush_ev "
+    \$index = search_api_index_load('site_content');
+    \$status = search_api_index_status(\$index);
+    echo \$status['indexed'];
+  ")
+
+  if [ -n "$INDEXED" ] && [ "$INDEXED" -gt 0 ] 2>/dev/null; then
+    echo "Indexed $INDEXED items."
   else
-    INDEXED=$(echo "$STATUS" | grep -o 'Indexed[[:space:]]*[0-9]*' | grep -o '[0-9]*')
-    if [ -n "$INDEXED" ] && [ "$INDEXED" -gt 0 ]; then
-      echo "Warning: Index not 100% but $INDEXED items indexed."
-    else
-      echo "::error::No items indexed: $STATUS"
-      exit 1
-    fi
+    echo "::error::No items indexed: $INDEXED"
+    exit 1
   fi
 
 else

--- a/.github/scripts/solr9-cuj7-create-index.sh
+++ b/.github/scripts/solr9-cuj7-create-index.sh
@@ -30,7 +30,15 @@ if [ "$MODULE" = "apachesolr" ]; then
   step "Step 2: Index content"
   terminus drush "$SITE_ENV" -- solr-index
 
-  step "Step 3: Verify index count"
+  step "Step 3: Commit index and verify count"
+  # Force Solr commit to ensure docs are searchable before CUJ 8
+  drush_ev "
+    \$env_id = apachesolr_default_environment();
+    \$solr = apachesolr_get_solr(\$env_id);
+    \$solr->commit();
+  " || true
+  sleep 5
+
   INDEX_STATS=$(drush_ev "
     \$env_id = apachesolr_default_environment();
     try {

--- a/.github/scripts/solr9-cuj8-validate-search.sh
+++ b/.github/scripts/solr9-cuj8-validate-search.sh
@@ -11,7 +11,7 @@ MODULE="${MODULE:?MODULE env var must be set}"
 step() { echo ""; echo ">>>>>>>>>> $1 <<<<<<<<<<"; echo ""; }
 
 drush_ev() {
-  terminus drush "$SITE_ENV" -- ev "$@" 2>/dev/null | tr -d '[:space:]'
+  terminus drush "$SITE_ENV" -- ev "$@" 2>/dev/null | tail -1 | tr -d '[:space:]'
 }
 
 step "CUJ 8: Validate Search Results ($MODULE)"

--- a/.github/scripts/solr9-cuj8-validate-search.sh
+++ b/.github/scripts/solr9-cuj8-validate-search.sh
@@ -10,10 +10,8 @@ MODULE="${MODULE:?MODULE env var must be set}"
 
 step() { echo ""; echo ">>>>>>>>>> $1 <<<<<<<<<<"; echo ""; }
 
-drush_ev_extract() {
-  local pattern="$1"
-  shift
-  terminus drush "$SITE_ENV" -- ev "$@" 2>&1 | grep -o "${pattern}[^ ]*" || true
+drush_ev() {
+  terminus drush "$SITE_ENV" -- ev "$@" 2>/dev/null | tr -d '[:space:]'
 }
 
 step "CUJ 8: Validate Search Results ($MODULE)"
@@ -21,55 +19,54 @@ step "CUJ 8: Validate Search Results ($MODULE)"
 step "Step 1: Search for known term"
 
 if [ "$MODULE" = "apachesolr" ]; then
-  SEARCH_RESULT=$(drush_ev_extract "FOUND:" "
+  COUNT=$(drush_ev "
     \$env_id = apachesolr_default_environment();
     \$solr = apachesolr_get_solr(\$env_id);
     \$response = \$solr->search('content:Solr', array('rows' => 10));
-    echo 'FOUND:' . \$response->response->numFound;
+    echo \$response->response->numFound;
   ")
 elif [ "$MODULE" = "search_api_solr" ]; then
-  SEARCH_RESULT=$(drush_ev_extract "FOUND:" "
+  COUNT=$(drush_ev "
     \$index = search_api_index_load('site_content');
     \$query = new SearchApiQuery(\$index);
     \$query->keys('Solr');
     \$query->range(0, 10);
     \$results = \$query->execute();
-    echo 'FOUND:' . \$results['result count'];
+    echo \$results['result count'];
   ")
 fi
 
-COUNT="${SEARCH_RESULT#FOUND:}"
 if [ -n "$COUNT" ] && [ "$COUNT" -gt 0 ] 2>/dev/null; then
   echo "Search for 'Solr' returned $COUNT results."
 else
-  echo "::error::Search for 'Solr' returned 0 results (expected > 0). Raw: $SEARCH_RESULT"
+  echo "::error::Search for 'Solr' returned 0 results (expected > 0)"
   exit 1
 fi
 
 step "Step 2: Search for non-existent term"
 
 if [ "$MODULE" = "apachesolr" ]; then
-  EMPTY_RESULT=$(drush_ev_extract "FOUND:" "
+  ZERO_COUNT=$(drush_ev "
     \$env_id = apachesolr_default_environment();
     \$solr = apachesolr_get_solr(\$env_id);
     \$response = \$solr->search('content:xyznonexistent99', array('rows' => 1));
-    echo 'FOUND:' . \$response->response->numFound;
+    echo \$response->response->numFound;
   ")
 elif [ "$MODULE" = "search_api_solr" ]; then
-  EMPTY_RESULT=$(drush_ev_extract "FOUND:" "
+  ZERO_COUNT=$(drush_ev "
     \$index = search_api_index_load('site_content');
     \$query = new SearchApiQuery(\$index);
     \$query->keys('xyznonexistent99');
     \$query->range(0, 1);
     \$results = \$query->execute();
-    echo 'FOUND:' . \$results['result count'];
+    echo \$results['result count'];
   ")
 fi
 
-if [ "$EMPTY_RESULT" = "FOUND:0" ]; then
+if [ "$ZERO_COUNT" = "0" ]; then
   echo "Search for non-existent term correctly returned 0 results."
 else
-  echo "::warning::Expected FOUND:0 for non-existent term, got: $EMPTY_RESULT"
+  echo "::warning::Expected 0 results for non-existent term, got: $ZERO_COUNT"
 fi
 
 step "Step 3: Check watchdog for Solr errors"
@@ -96,7 +93,7 @@ fi
 
 step "Step 4: Verify Solr ping"
 
-PING=$(drush_ev_extract "PING_" "
+PING=$(drush_ev "
   \$host = PANTHEON_APACHESOLR_HOST;
   \$path = getenv('PANTHEON_INDEX_PATH') . getenv('PANTHEON_INDEX_CORE') . '/admin/ping';
   if ('$MODULE' === 'search_api_solr') {
@@ -111,7 +108,7 @@ PING=$(drush_ev_extract "PING_" "
   \$response = curl_exec(\$ch);
   \$info = curl_getinfo(\$ch);
   curl_close(\$ch);
-  echo in_array(\$info['http_code'], array(200, 201, 202, 204)) ? 'PING_OK' : 'PING_FAILED:' . \$info['http_code'];
+  echo in_array(\$info['http_code'], array(200, 201, 202, 204)) ? 'PING_OK' : 'PING_FAILED';
 ")
 
 if [ "$PING" = "PING_OK" ]; then

--- a/.github/scripts/solr9-cuj8-validate-search.sh
+++ b/.github/scripts/solr9-cuj8-validate-search.sh
@@ -11,7 +11,7 @@ MODULE="${MODULE:?MODULE env var must be set}"
 step() { echo ""; echo ">>>>>>>>>> $1 <<<<<<<<<<"; echo ""; }
 
 drush_ev() {
-  terminus drush "$SITE_ENV" -- ev "$@" 2>&1 | grep -v "^\[warning\]\|^\[notice\]\|^\[error\]\|^Warning:\|^Notice:\|^Command:\|drush.in\|Exit:" | tail -1 | tr -d '[:space:]'
+  terminus drush "$SITE_ENV" -- ev "$@" 2>&1
 }
 
 step "CUJ 8: Validate Search Results ($MODULE)"
@@ -19,24 +19,25 @@ step "CUJ 8: Validate Search Results ($MODULE)"
 step "Step 1: Search for known term"
 
 if [ "$MODULE" = "apachesolr" ]; then
-  COUNT=$(drush_ev "
+  SEARCH_RESULT=$(drush_ev "
     \$env_id = apachesolr_default_environment();
     \$solr = apachesolr_get_solr(\$env_id);
     \$response = \$solr->search('content:Solr', array('rows' => 10));
-    echo \$response->response->numFound;
-  ")
+    echo 'FOUND:' . \$response->response->numFound;
+  ") || true
 elif [ "$MODULE" = "search_api_solr" ]; then
-  COUNT=$(drush_ev "
+  SEARCH_RESULT=$(drush_ev "
     \$index = search_api_index_load('site_content');
     \$query = new SearchApiQuery(\$index);
     \$query->keys('Solr');
     \$query->range(0, 10);
     \$results = \$query->execute();
-    echo \$results['result count'];
-  ")
+    echo 'FOUND:' . \$results['result count'];
+  ") || true
 fi
 
-if [ -n "$COUNT" ] && [ "$COUNT" -gt 0 ] 2>/dev/null; then
+if echo "$SEARCH_RESULT" | grep -qE "FOUND:[1-9]"; then
+  COUNT=$(echo "$SEARCH_RESULT" | grep -o 'FOUND:[0-9]*' | head -1 | cut -d: -f2)
   echo "Search for 'Solr' returned $COUNT results."
 else
   echo "::error::Search for 'Solr' returned 0 results (expected > 0)"
@@ -46,27 +47,27 @@ fi
 step "Step 2: Search for non-existent term"
 
 if [ "$MODULE" = "apachesolr" ]; then
-  ZERO_COUNT=$(drush_ev "
+  EMPTY_RESULT=$(drush_ev "
     \$env_id = apachesolr_default_environment();
     \$solr = apachesolr_get_solr(\$env_id);
     \$response = \$solr->search('content:xyznonexistent99', array('rows' => 1));
-    echo \$response->response->numFound;
-  ")
+    echo 'FOUND:' . \$response->response->numFound;
+  ") || true
 elif [ "$MODULE" = "search_api_solr" ]; then
-  ZERO_COUNT=$(drush_ev "
+  EMPTY_RESULT=$(drush_ev "
     \$index = search_api_index_load('site_content');
     \$query = new SearchApiQuery(\$index);
     \$query->keys('xyznonexistent99');
     \$query->range(0, 1);
     \$results = \$query->execute();
-    echo \$results['result count'];
-  ")
+    echo 'FOUND:' . \$results['result count'];
+  ") || true
 fi
 
-if [ "$ZERO_COUNT" = "0" ]; then
+if echo "$EMPTY_RESULT" | grep -q "FOUND:0"; then
   echo "Search for non-existent term correctly returned 0 results."
 else
-  echo "::warning::Expected 0 results for non-existent term, got: $ZERO_COUNT"
+  echo "::warning::Expected 0 results for non-existent term"
 fi
 
 step "Step 3: Check watchdog for Solr errors"
@@ -109,12 +110,12 @@ PING=$(drush_ev "
   \$info = curl_getinfo(\$ch);
   curl_close(\$ch);
   echo in_array(\$info['http_code'], array(200, 201, 202, 204)) ? 'PING_OK' : 'PING_FAILED';
-")
+") || true
 
-if [ "$PING" = "PING_OK" ]; then
+if echo "$PING" | grep -q "PING_OK"; then
   echo "Solr ping healthy."
 else
-  echo "::error::Solr ping failed: $PING"
+  echo "::error::Solr ping failed"
   exit 1
 fi
 

--- a/.github/scripts/solr9-cuj8-validate-search.sh
+++ b/.github/scripts/solr9-cuj8-validate-search.sh
@@ -1,0 +1,116 @@
+#!/bin/bash
+set -euo pipefail
+
+# CUJ 8: Validate That Solr 9 is Serving Search Results
+# Tests that indexed content is searchable and results are correct.
+# Accepts MODULE env var: apachesolr or search_api_solr
+
+SITE_ENV="${TERMINUS_SITE}.${MULTIDEV}"
+MODULE="${MODULE:?MODULE env var must be set}"
+
+echo "=== CUJ 8: Validate Search Results ($MODULE) ==="
+
+# Step 1: Search for a known term that should return results
+echo "--- Step 1: Search for known term ---"
+
+if [ "$MODULE" = "apachesolr" ]; then
+  SEARCH_RESULT=$(terminus drush "$SITE_ENV" -- ev "
+    \$env_id = apachesolr_default_environment();
+    \$solr = apachesolr_get_solr(\$env_id);
+    \$response = \$solr->search('content:Solr', array('rows' => 10));
+    echo 'FOUND:' . \$response->response->numFound;
+  " 2>&1)
+elif [ "$MODULE" = "search_api_solr" ]; then
+  SEARCH_RESULT=$(terminus drush "$SITE_ENV" -- ev "
+    \$index = search_api_index_load('site_content');
+    \$query = new SearchApiQuery(\$index);
+    \$query->keys('Solr');
+    \$query->range(0, 10);
+    \$results = \$query->execute();
+    echo 'FOUND:' . \$results['result count'];
+  " 2>&1)
+fi
+
+if echo "$SEARCH_RESULT" | grep -q "FOUND:"; then
+  COUNT=$(echo "$SEARCH_RESULT" | grep -o 'FOUND:[0-9]*' | cut -d: -f2)
+  if [ "$COUNT" -gt 0 ]; then
+    echo "Search for 'Solr' returned $COUNT results."
+  else
+    echo "::error::Search for 'Solr' returned 0 results (expected > 0)"
+    exit 1
+  fi
+else
+  echo "::error::Search query failed: $SEARCH_RESULT"
+  exit 1
+fi
+
+# Step 2: Search for a term that should return zero results
+echo "--- Step 2: Search for non-existent term ---"
+
+if [ "$MODULE" = "apachesolr" ]; then
+  EMPTY_RESULT=$(terminus drush "$SITE_ENV" -- ev "
+    \$env_id = apachesolr_default_environment();
+    \$solr = apachesolr_get_solr(\$env_id);
+    \$response = \$solr->search('content:xyznonexistent99', array('rows' => 1));
+    echo 'FOUND:' . \$response->response->numFound;
+  " 2>&1)
+elif [ "$MODULE" = "search_api_solr" ]; then
+  EMPTY_RESULT=$(terminus drush "$SITE_ENV" -- ev "
+    \$index = search_api_index_load('site_content');
+    \$query = new SearchApiQuery(\$index);
+    \$query->keys('xyznonexistent99');
+    \$query->range(0, 1);
+    \$results = \$query->execute();
+    echo 'FOUND:' . \$results['result count'];
+  " 2>&1)
+fi
+
+if echo "$EMPTY_RESULT" | grep -q "FOUND:0"; then
+  echo "Search for non-existent term correctly returned 0 results."
+else
+  echo "::warning::Expected 0 results for non-existent term: $EMPTY_RESULT"
+fi
+
+# Step 3: Check watchdog for Solr errors
+echo "--- Step 3: Check watchdog for Solr errors ---"
+
+ERRORS=$(terminus drush "$SITE_ENV" -- watchdog-show --type=pantheon_apachesolr --severity=error --count=5 2>&1)
+
+if echo "$ERRORS" | grep -qiE "No log messages available|No results"; then
+  echo "No Solr errors in watchdog."
+elif echo "$ERRORS" | grep -qi "error"; then
+  echo "::warning::Solr errors found in watchdog:"
+  echo "$ERRORS"
+else
+  echo "No Solr errors in watchdog."
+fi
+
+# Step 4: Verify Solr ping is healthy
+echo "--- Step 4: Verify Solr ping ---"
+
+PING=$(terminus drush "$SITE_ENV" -- ev "
+  \$host = PANTHEON_APACHESOLR_HOST;
+  \$path = getenv('PANTHEON_INDEX_PATH') . getenv('PANTHEON_INDEX_CORE') . '/admin/ping';
+  if ('$MODULE' === 'search_api_solr') {
+    \$path .= '?q=id:1';
+  }
+  \$url = 'https://' . \$host . '/' . \$path;
+  list(\$ch, \$opts) = pantheon_apachesolr_curl_setup(\$url, PANTHEON_APACHESOLR_PORT);
+  \$opts = pantheon_apachesolr_curlopts(\$opts);
+  \$opts[CURLOPT_CONNECTTIMEOUT] = 5;
+  \$opts[CURLOPT_RETURNTRANSFER] = 1;
+  curl_setopt_array(\$ch, \$opts);
+  \$response = curl_exec(\$ch);
+  \$info = curl_getinfo(\$ch);
+  curl_close(\$ch);
+  echo in_array(\$info['http_code'], array(200, 201, 202, 204)) ? 'PING_OK' : 'PING_FAILED:' . \$info['http_code'];
+" 2>&1)
+
+if echo "$PING" | grep -q "PING_OK"; then
+  echo "Solr ping healthy."
+else
+  echo "::error::Solr ping failed: $PING"
+  exit 1
+fi
+
+echo "=== CUJ 8 PASSED: $MODULE search results validated ==="

--- a/.github/scripts/solr9-cuj8-validate-search.sh
+++ b/.github/scripts/solr9-cuj8-validate-search.sh
@@ -23,7 +23,7 @@ if [ "$MODULE" = "apachesolr" ]; then
     \$env_id = apachesolr_default_environment();
     \$solr = apachesolr_get_solr(\$env_id);
     \$response = \$solr->search('content:Solr', array('rows' => 10));
-    echo 'FOUND:' . \$response->response->numFound;
+    echo 'FOUND:' . \$response->response->numFound . ' ';
   ") || true
 elif [ "$MODULE" = "search_api_solr" ]; then
   SEARCH_RESULT=$(drush_ev "
@@ -32,7 +32,7 @@ elif [ "$MODULE" = "search_api_solr" ]; then
     \$query->keys('Solr');
     \$query->range(0, 10);
     \$results = \$query->execute();
-    echo 'FOUND:' . \$results['result count'];
+    echo 'FOUND:' . \$results['result count'] . ' ';
   ") || true
 fi
 
@@ -51,7 +51,7 @@ if [ "$MODULE" = "apachesolr" ]; then
     \$env_id = apachesolr_default_environment();
     \$solr = apachesolr_get_solr(\$env_id);
     \$response = \$solr->search('content:xyznonexistent99', array('rows' => 1));
-    echo 'FOUND:' . \$response->response->numFound;
+    echo 'FOUND:' . \$response->response->numFound . ' ';
   ") || true
 elif [ "$MODULE" = "search_api_solr" ]; then
   EMPTY_RESULT=$(drush_ev "
@@ -60,7 +60,7 @@ elif [ "$MODULE" = "search_api_solr" ]; then
     \$query->keys('xyznonexistent99');
     \$query->range(0, 1);
     \$results = \$query->execute();
-    echo 'FOUND:' . \$results['result count'];
+    echo 'FOUND:' . \$results['result count'] . ' ';
   ") || true
 fi
 

--- a/.github/scripts/solr9-cuj8-validate-search.sh
+++ b/.github/scripts/solr9-cuj8-validate-search.sh
@@ -20,10 +20,8 @@ step "Step 1: Search for known term"
 
 if [ "$MODULE" = "apachesolr" ]; then
   SEARCH_RESULT=$(drush_ev "
-    \$env_id = apachesolr_default_environment();
-    \$solr = apachesolr_get_solr(\$env_id);
-    \$response = \$solr->search('content:Solr', array('rows' => 10));
-    echo 'FOUND:' . \$response->response->numFound . ' ';
+    \$results = node_search_execute('Solr');
+    echo 'FOUND:' . count(\$results) . ' ';
   ") || true
 elif [ "$MODULE" = "search_api_solr" ]; then
   SEARCH_RESULT=$(drush_ev "
@@ -48,10 +46,8 @@ step "Step 2: Search for non-existent term"
 
 if [ "$MODULE" = "apachesolr" ]; then
   EMPTY_RESULT=$(drush_ev "
-    \$env_id = apachesolr_default_environment();
-    \$solr = apachesolr_get_solr(\$env_id);
-    \$response = \$solr->search('content:xyznonexistent99', array('rows' => 1));
-    echo 'FOUND:' . \$response->response->numFound . ' ';
+    \$results = node_search_execute('xyznonexistent99');
+    echo 'FOUND:' . count(\$results) . ' ';
   ") || true
 elif [ "$MODULE" = "search_api_solr" ]; then
   EMPTY_RESULT=$(drush_ev "

--- a/.github/scripts/solr9-cuj8-validate-search.sh
+++ b/.github/scripts/solr9-cuj8-validate-search.sh
@@ -8,11 +8,8 @@ set -euo pipefail
 SITE_ENV="${TERMINUS_SITE}.${MULTIDEV}"
 MODULE="${MODULE:?MODULE env var must be set}"
 
-step() { echo ""; echo ">>>>>>>>>> $1 <<<<<<<<<<"; echo ""; }
-
-drush_ev() {
-  terminus drush "$SITE_ENV" -- ev "$@" 2>&1
-}
+# shellcheck source=.github/scripts/solr9-shared.sh
+source "$(dirname "$0")/solr9-shared.sh"
 
 step "CUJ 8: Validate Search Results ($MODULE)"
 

--- a/.github/scripts/solr9-cuj8-validate-search.sh
+++ b/.github/scripts/solr9-cuj8-validate-search.sh
@@ -8,71 +8,71 @@ set -euo pipefail
 SITE_ENV="${TERMINUS_SITE}.${MULTIDEV}"
 MODULE="${MODULE:?MODULE env var must be set}"
 
-echo "=== CUJ 8: Validate Search Results ($MODULE) ==="
+step() { echo ""; echo ">>>>>>>>>> $1 <<<<<<<<<<"; echo ""; }
 
-# Step 1: Search for a known term that should return results
-echo "--- Step 1: Search for known term ---"
+drush_ev_extract() {
+  local pattern="$1"
+  shift
+  terminus drush "$SITE_ENV" -- ev "$@" 2>&1 | grep -o "${pattern}[^ ]*" || true
+}
+
+step "CUJ 8: Validate Search Results ($MODULE)"
+
+step "Step 1: Search for known term"
 
 if [ "$MODULE" = "apachesolr" ]; then
-  SEARCH_RESULT=$(terminus drush "$SITE_ENV" -- ev "
+  SEARCH_RESULT=$(drush_ev_extract "FOUND:" "
     \$env_id = apachesolr_default_environment();
     \$solr = apachesolr_get_solr(\$env_id);
     \$response = \$solr->search('content:Solr', array('rows' => 10));
     echo 'FOUND:' . \$response->response->numFound;
-  " 2>&1)
+  ")
 elif [ "$MODULE" = "search_api_solr" ]; then
-  SEARCH_RESULT=$(terminus drush "$SITE_ENV" -- ev "
+  SEARCH_RESULT=$(drush_ev_extract "FOUND:" "
     \$index = search_api_index_load('site_content');
     \$query = new SearchApiQuery(\$index);
     \$query->keys('Solr');
     \$query->range(0, 10);
     \$results = \$query->execute();
     echo 'FOUND:' . \$results['result count'];
-  " 2>&1)
+  ")
 fi
 
-if echo "$SEARCH_RESULT" | grep -q "FOUND:"; then
-  COUNT=$(echo "$SEARCH_RESULT" | grep -o 'FOUND:[0-9]*' | cut -d: -f2)
-  if [ "$COUNT" -gt 0 ]; then
-    echo "Search for 'Solr' returned $COUNT results."
-  else
-    echo "::error::Search for 'Solr' returned 0 results (expected > 0)"
-    exit 1
-  fi
+COUNT="${SEARCH_RESULT#FOUND:}"
+if [ -n "$COUNT" ] && [ "$COUNT" -gt 0 ] 2>/dev/null; then
+  echo "Search for 'Solr' returned $COUNT results."
 else
-  echo "::error::Search query failed: $SEARCH_RESULT"
+  echo "::error::Search for 'Solr' returned 0 results (expected > 0). Raw: $SEARCH_RESULT"
   exit 1
 fi
 
-# Step 2: Search for a term that should return zero results
-echo "--- Step 2: Search for non-existent term ---"
+step "Step 2: Search for non-existent term"
 
 if [ "$MODULE" = "apachesolr" ]; then
-  EMPTY_RESULT=$(terminus drush "$SITE_ENV" -- ev "
+  EMPTY_RESULT=$(drush_ev_extract "FOUND:" "
     \$env_id = apachesolr_default_environment();
     \$solr = apachesolr_get_solr(\$env_id);
     \$response = \$solr->search('content:xyznonexistent99', array('rows' => 1));
     echo 'FOUND:' . \$response->response->numFound;
-  " 2>&1)
+  ")
 elif [ "$MODULE" = "search_api_solr" ]; then
-  EMPTY_RESULT=$(terminus drush "$SITE_ENV" -- ev "
+  EMPTY_RESULT=$(drush_ev_extract "FOUND:" "
     \$index = search_api_index_load('site_content');
     \$query = new SearchApiQuery(\$index);
     \$query->keys('xyznonexistent99');
     \$query->range(0, 1);
     \$results = \$query->execute();
     echo 'FOUND:' . \$results['result count'];
-  " 2>&1)
+  ")
 fi
 
-if echo "$EMPTY_RESULT" | grep -q "FOUND:0"; then
+if [ "$EMPTY_RESULT" = "FOUND:0" ]; then
   echo "Search for non-existent term correctly returned 0 results."
 else
-  echo "::warning::Expected 0 results for non-existent term: $EMPTY_RESULT"
+  echo "::warning::Expected FOUND:0 for non-existent term, got: $EMPTY_RESULT"
 fi
 
-# Step 3: Check watchdog for Solr errors
-echo "--- Step 3: Check watchdog for Solr errors ---"
+step "Step 3: Check watchdog for Solr errors"
 
 if [ "$MODULE" = "apachesolr" ]; then
   WD_TYPE="Apache Solr"
@@ -82,10 +82,9 @@ fi
 
 ERRORS=$(terminus drush "$SITE_ENV" -- watchdog-show "--type=$WD_TYPE" --count=10 2>&1) || true
 
-if echo "$ERRORS" | grep -qiE "Unrecognized message type\|No log messages"; then
+if echo "$ERRORS" | grep -qiE "Unrecognized message type|No log messages"; then
   echo "No Solr log entries in watchdog (type '$WD_TYPE' not present)."
 else
-  # Filter out drush meta lines, check for actual error entries
   REAL_ERRORS=$(echo "$ERRORS" | grep -i "error" | grep -vi "Unrecognized message type\|Exit:\|Command:" || true)
   if [ -n "$REAL_ERRORS" ]; then
     echo "::warning::Solr errors found in watchdog:"
@@ -95,10 +94,9 @@ else
   fi
 fi
 
-# Step 4: Verify Solr ping is healthy
-echo "--- Step 4: Verify Solr ping ---"
+step "Step 4: Verify Solr ping"
 
-PING=$(terminus drush "$SITE_ENV" -- ev "
+PING=$(drush_ev_extract "PING_" "
   \$host = PANTHEON_APACHESOLR_HOST;
   \$path = getenv('PANTHEON_INDEX_PATH') . getenv('PANTHEON_INDEX_CORE') . '/admin/ping';
   if ('$MODULE' === 'search_api_solr') {
@@ -114,13 +112,13 @@ PING=$(terminus drush "$SITE_ENV" -- ev "
   \$info = curl_getinfo(\$ch);
   curl_close(\$ch);
   echo in_array(\$info['http_code'], array(200, 201, 202, 204)) ? 'PING_OK' : 'PING_FAILED:' . \$info['http_code'];
-" 2>&1)
+")
 
-if echo "$PING" | grep -q "PING_OK"; then
+if [ "$PING" = "PING_OK" ]; then
   echo "Solr ping healthy."
 else
   echo "::error::Solr ping failed: $PING"
   exit 1
 fi
 
-echo "=== CUJ 8 PASSED: $MODULE search results validated ==="
+step "CUJ 8 PASSED: $MODULE search results validated"

--- a/.github/scripts/solr9-cuj8-validate-search.sh
+++ b/.github/scripts/solr9-cuj8-validate-search.sh
@@ -74,15 +74,25 @@ fi
 # Step 3: Check watchdog for Solr errors
 echo "--- Step 3: Check watchdog for Solr errors ---"
 
-ERRORS=$(terminus drush "$SITE_ENV" -- watchdog-show "--type=Apache Solr" --count=10 2>&1) || true
+if [ "$MODULE" = "apachesolr" ]; then
+  WD_TYPE="Apache Solr"
+else
+  WD_TYPE="search_api_solr"
+fi
+
+ERRORS=$(terminus drush "$SITE_ENV" -- watchdog-show "--type=$WD_TYPE" --count=10 2>&1) || true
 
 if echo "$ERRORS" | grep -qiE "Unrecognized message type\|No log messages"; then
-  echo "No Solr log entries in watchdog."
-elif echo "$ERRORS" | grep -qi "error"; then
-  echo "::warning::Solr entries found in watchdog:"
-  echo "$ERRORS"
+  echo "No Solr log entries in watchdog (type '$WD_TYPE' not present)."
 else
-  echo "No Solr errors in watchdog."
+  # Filter out drush meta lines, check for actual error entries
+  REAL_ERRORS=$(echo "$ERRORS" | grep -i "error" | grep -vi "Unrecognized message type\|Exit:\|Command:" || true)
+  if [ -n "$REAL_ERRORS" ]; then
+    echo "::warning::Solr errors found in watchdog:"
+    echo "$REAL_ERRORS"
+  else
+    echo "No Solr errors in watchdog."
+  fi
 fi
 
 # Step 4: Verify Solr ping is healthy

--- a/.github/scripts/solr9-cuj8-validate-search.sh
+++ b/.github/scripts/solr9-cuj8-validate-search.sh
@@ -11,7 +11,7 @@ MODULE="${MODULE:?MODULE env var must be set}"
 step() { echo ""; echo ">>>>>>>>>> $1 <<<<<<<<<<"; echo ""; }
 
 drush_ev() {
-  terminus drush "$SITE_ENV" -- ev "$@" 2>/dev/null | tail -1 | tr -d '[:space:]'
+  terminus drush "$SITE_ENV" -- ev "$@" 2>&1 | grep -v "^\[warning\]\|^\[notice\]\|^\[error\]\|^Warning:\|^Notice:\|^Command:\|drush.in\|Exit:" | tail -1 | tr -d '[:space:]'
 }
 
 step "CUJ 8: Validate Search Results ($MODULE)"

--- a/.github/scripts/solr9-cuj8-validate-search.sh
+++ b/.github/scripts/solr9-cuj8-validate-search.sh
@@ -74,12 +74,12 @@ fi
 # Step 3: Check watchdog for Solr errors
 echo "--- Step 3: Check watchdog for Solr errors ---"
 
-ERRORS=$(terminus drush "$SITE_ENV" -- watchdog-show --type=pantheon_apachesolr --severity=error --count=5 2>&1)
+ERRORS=$(terminus drush "$SITE_ENV" -- watchdog-show "--type=Apache Solr" --count=10 2>&1) || true
 
-if echo "$ERRORS" | grep -qiE "No log messages available|No results"; then
-  echo "No Solr errors in watchdog."
+if echo "$ERRORS" | grep -qiE "Unrecognized message type\|No log messages"; then
+  echo "No Solr log entries in watchdog."
 elif echo "$ERRORS" | grep -qi "error"; then
-  echo "::warning::Solr errors found in watchdog:"
+  echo "::warning::Solr entries found in watchdog:"
   echo "$ERRORS"
 else
   echo "No Solr errors in watchdog."

--- a/.github/scripts/solr9-setup-multidev.sh
+++ b/.github/scripts/solr9-setup-multidev.sh
@@ -51,8 +51,8 @@ cat pantheon.yml
 
 # Push code to Pantheon (pantheon_apachesolr + Solr 9 config)
 git add -A
-git commit -m "CI: Solr 9 CUJ test - $MODULE (run $GITHUB_RUN_NUMBER)"
-git push origin "$MULTIDEV"
+git commit -m "CI: Solr 9 CUJ test - $MODULE (run $GITHUB_RUN_NUMBER)" || echo "No changes to commit"
+git push origin "$MULTIDEV" || echo "Nothing to push"
 
 cd ..
 

--- a/.github/scripts/solr9-setup-multidev.sh
+++ b/.github/scripts/solr9-setup-multidev.sh
@@ -63,8 +63,7 @@ step "Verifying environment"
 terminus env:info "$SITE_ENV"
 
 step "Checking Solr version"
-SOLR_VER=$(terminus drush "$SITE_ENV" -- ev "echo 'SOLR_VER:' . (isset(\$_ENV['search_version']) ? \$_ENV['search_version'] : 'not_set');" 2>&1 | grep -o 'SOLR_VER:[^ ]*' || true)
-SOLR_VER="${SOLR_VER#SOLR_VER:}"
+SOLR_VER=$(terminus drush "$SITE_ENV" -- ev "echo \$_ENV['search_version'] ?? 'not_set';" 2>/dev/null | tr -d '[:space:]')
 echo "Solr version: $SOLR_VER"
 if [ "$SOLR_VER" != "9" ]; then
   echo "::error::Expected Solr version 9, got: $SOLR_VER"

--- a/.github/scripts/solr9-setup-multidev.sh
+++ b/.github/scripts/solr9-setup-multidev.sh
@@ -9,7 +9,8 @@ MULTIDEV="$1"
 TERMINUS_SITE="$2"
 MODULE="${MODULE:?MODULE env var must be set (apachesolr or search_api_solr)}"
 
-step() { echo ""; echo ">>>>>>>>>> $1 <<<<<<<<<<"; echo ""; }
+# shellcheck source=.github/scripts/solr9-shared.sh
+source "$(dirname "$0")/solr9-shared.sh"
 
 step "Phase 1: Create multidev and configure Solr 9"
 

--- a/.github/scripts/solr9-setup-multidev.sh
+++ b/.github/scripts/solr9-setup-multidev.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+set -euo pipefail
+
+# Create a Pantheon multidev with Solr 9 configured for D7 CUJ testing.
+# Clones the fixture site's dev environment, sets search version to 9,
+# pushes the current branch code, and installs the target search module.
+
+MULTIDEV="$1"
+TERMINUS_SITE="$2"
+MODULE="${MODULE:?MODULE env var must be set (apachesolr or search_api_solr)}"
+
+echo "=== Phase 1: Create multidev and configure Solr 9 ==="
+
+# Delete existing multidev if present (from a previous failed run)
+if terminus multidev:list "$TERMINUS_SITE" --format=list 2>/dev/null | grep -q "^$MULTIDEV$"; then
+  echo "Deleting existing multidev: $MULTIDEV"
+  terminus multidev:delete "$TERMINUS_SITE.$MULTIDEV" --delete-branch --yes
+fi
+
+# Create multidev from dev (inherits database with seeded content)
+echo "Creating multidev $MULTIDEV from dev..."
+terminus multidev:create "$TERMINUS_SITE.dev" "$MULTIDEV"
+
+# Clone the Pantheon site repo to push code changes
+echo "Cloning Pantheon site repo..."
+GIT_URL=$(terminus connection:info "$TERMINUS_SITE.$MULTIDEV" --field=git_url)
+GIT_SSH_COMMAND="ssh -o StrictHostKeyChecking=no" git clone "$GIT_URL" pantheon-site
+
+cd pantheon-site
+git checkout "$MULTIDEV"
+
+# Copy the pantheon_apachesolr module from the current branch
+echo "Copying pantheon_apachesolr module..."
+rm -rf modules/pantheon/pantheon_apachesolr
+cp -r "$GITHUB_WORKSPACE/modules/pantheon/pantheon_apachesolr" modules/pantheon/pantheon_apachesolr
+
+# Set Solr 9 in pantheon.yml
+echo "Setting search version to 9 in pantheon.yml..."
+if [ -f pantheon.upstream.yml ]; then
+  cp pantheon.upstream.yml pantheon.yml
+fi
+if grep -q "^search:" pantheon.yml 2>/dev/null; then
+  sed -i "s/^\([[:space:]]*\)version: [0-9]*/\1version: 9/" pantheon.yml
+else
+  echo "search:" >> pantheon.yml
+  echo "  version: 9" >> pantheon.yml
+fi
+
+echo "pantheon.yml contents:"
+cat pantheon.yml
+
+# Push code to Pantheon (pantheon_apachesolr + Solr 9 config)
+git add -A
+git commit -m "CI: Solr 9 CUJ test - $MODULE (run $GITHUB_RUN_NUMBER)"
+git push origin "$MULTIDEV"
+
+cd ..
+
+# Wait for platform build and Solr provisioning
+echo "Waiting for Pantheon workflow to complete..."
+terminus workflow:wait "$TERMINUS_SITE.$MULTIDEV" --max=600
+
+SITE_ENV="$TERMINUS_SITE.$MULTIDEV"
+
+# Verify Solr 9 is provisioned
+echo "Verifying environment..."
+terminus env:info "$SITE_ENV"
+
+# Enable base modules (search, update manager, tag1_d7es, pantheon_apachesolr)
+echo "Enabling base modules..."
+terminus drush "$SITE_ENV" -- en search update tag1_d7es pantheon_apachesolr -y
+
+# Switch to SFTP mode to download modules via drush dl (closer to user journey)
+echo "Switching to SFTP mode..."
+terminus connection:set "$SITE_ENV" sftp
+
+# Download and install target search module via Tag1 D7ES update server
+echo "Downloading $MODULE via drush dl (Tag1 D7ES)..."
+
+if [ "$MODULE" = "apachesolr" ]; then
+  terminus drush "$SITE_ENV" -- dl apachesolr-7.x-1.15 -y
+  echo "Enabling apachesolr and apachesolr_search..."
+  terminus drush "$SITE_ENV" -- en apachesolr apachesolr_search -y
+
+elif [ "$MODULE" = "search_api_solr" ]; then
+  terminus drush "$SITE_ENV" -- dl entity search_api -y
+  terminus drush "$SITE_ENV" -- dl search_api_solr-7.x-1.19 -y
+  echo "Enabling entity, search_api, search_api_solr..."
+  terminus drush "$SITE_ENV" -- en entity search_api search_api_solr -y
+
+else
+  echo "::error::Unknown module: $MODULE"
+  exit 1
+fi
+
+# Commit SFTP changes and switch back to git mode
+echo "Committing SFTP changes..."
+terminus env:commit "$SITE_ENV" --message="CI: Install $MODULE module" --force
+terminus connection:set "$SITE_ENV" git
+
+echo "Verifying modules are enabled..."
+terminus drush "$SITE_ENV" -- pm-list --status=enabled --type=module | grep -iE "$MODULE|pantheon_apachesolr"
+
+echo "=== Phase 1 complete: Multidev $MULTIDEV ready with Solr 9 + $MODULE ==="

--- a/.github/scripts/solr9-setup-multidev.sh
+++ b/.github/scripts/solr9-setup-multidev.sh
@@ -34,18 +34,6 @@ step "Copying pantheon_apachesolr module"
 rm -rf modules/pantheon/pantheon_apachesolr
 cp -r "$GITHUB_WORKSPACE/modules/pantheon/pantheon_apachesolr" modules/pantheon/pantheon_apachesolr
 
-step "Setting search version to 9 in pantheon.yml"
-touch pantheon.yml
-if grep -q "^search:" pantheon.yml; then
-  sed -i "s/^\([[:space:]]*\)version: [0-9]*/\1version: 9/" pantheon.yml
-else
-  echo "search:" >> pantheon.yml
-  echo "  version: 9" >> pantheon.yml
-fi
-
-echo "pantheon.yml contents:"
-cat pantheon.yml
-
 step "Pushing code to Pantheon"
 git add -A
 git commit -m "CI: Solr 9 CUJ test - $MODULE (run $GITHUB_RUN_NUMBER)" || echo "No changes to commit"

--- a/.github/scripts/solr9-setup-multidev.sh
+++ b/.github/scripts/solr9-setup-multidev.sh
@@ -63,7 +63,8 @@ step "Verifying environment"
 terminus env:info "$SITE_ENV"
 
 step "Checking Solr version"
-SOLR_VER=$(terminus drush "$SITE_ENV" -- ev "echo isset(\$_ENV['search_version']) ? \$_ENV['search_version'] : 'not set';" 2>&1 | head -1)
+SOLR_VER=$(terminus drush "$SITE_ENV" -- ev "echo 'SOLR_VER:' . (isset(\$_ENV['search_version']) ? \$_ENV['search_version'] : 'not_set');" 2>&1 | grep -o 'SOLR_VER:[^ ]*' || true)
+SOLR_VER="${SOLR_VER#SOLR_VER:}"
 echo "Solr version: $SOLR_VER"
 if [ "$SOLR_VER" != "9" ]; then
   echo "::error::Expected Solr version 9, got: $SOLR_VER"

--- a/.github/scripts/solr9-setup-multidev.sh
+++ b/.github/scripts/solr9-setup-multidev.sh
@@ -9,33 +9,31 @@ MULTIDEV="$1"
 TERMINUS_SITE="$2"
 MODULE="${MODULE:?MODULE env var must be set (apachesolr or search_api_solr)}"
 
-echo "=== Phase 1: Create multidev and configure Solr 9 ==="
+step() { echo ""; echo ">>>>>>>>>> $1 <<<<<<<<<<"; echo ""; }
+
+step "Phase 1: Create multidev and configure Solr 9"
 
 # Delete existing multidev if present (from a previous failed run)
 if terminus multidev:list "$TERMINUS_SITE" --format=list 2>/dev/null | grep -q "^$MULTIDEV$"; then
-  echo "Deleting existing multidev: $MULTIDEV"
+  step "Deleting existing multidev: $MULTIDEV"
   terminus multidev:delete "$TERMINUS_SITE.$MULTIDEV" --delete-branch --yes
 fi
 
-# Create multidev from dev (inherits database with seeded content)
-echo "Creating multidev $MULTIDEV from dev..."
+step "Creating multidev $MULTIDEV from dev"
 terminus multidev:create "$TERMINUS_SITE.dev" "$MULTIDEV"
 
-# Clone the Pantheon site repo to push code changes
-echo "Cloning Pantheon site repo..."
+step "Cloning Pantheon site repo"
 GIT_URL=$(terminus connection:info "$TERMINUS_SITE.$MULTIDEV" --field=git_url)
 GIT_SSH_COMMAND="ssh -o StrictHostKeyChecking=no" git clone "$GIT_URL" pantheon-site
 
 cd pantheon-site
 git checkout "$MULTIDEV"
 
-# Copy the pantheon_apachesolr module from the current branch
-echo "Copying pantheon_apachesolr module..."
+step "Copying pantheon_apachesolr module"
 rm -rf modules/pantheon/pantheon_apachesolr
 cp -r "$GITHUB_WORKSPACE/modules/pantheon/pantheon_apachesolr" modules/pantheon/pantheon_apachesolr
 
-# Set Solr 9 in pantheon.yml
-echo "Setting search version to 9 in pantheon.yml..."
+step "Setting search version to 9 in pantheon.yml"
 if [ -f pantheon.upstream.yml ]; then
   cp pantheon.upstream.yml pantheon.yml
 fi
@@ -49,43 +47,48 @@ fi
 echo "pantheon.yml contents:"
 cat pantheon.yml
 
-# Push code to Pantheon (pantheon_apachesolr + Solr 9 config)
+step "Pushing code to Pantheon"
 git add -A
 git commit -m "CI: Solr 9 CUJ test - $MODULE (run $GITHUB_RUN_NUMBER)" || echo "No changes to commit"
 git push origin "$MULTIDEV" || echo "Nothing to push"
 
 cd ..
 
-# Wait for platform build and Solr provisioning
-echo "Waiting for Pantheon workflow to complete..."
+step "Waiting for Pantheon workflow to complete"
 terminus workflow:wait "$TERMINUS_SITE.$MULTIDEV" --max=600
 
 SITE_ENV="$TERMINUS_SITE.$MULTIDEV"
 
-# Verify Solr 9 is provisioned
-echo "Verifying environment..."
+step "Verifying environment"
 terminus env:info "$SITE_ENV"
 
-# Enable base modules (search, update manager, tag1_d7es, pantheon_apachesolr)
-echo "Enabling base modules..."
+step "Checking Solr version"
+SOLR_VER=$(terminus drush "$SITE_ENV" -- ev "echo isset(\$_ENV['search_version']) ? \$_ENV['search_version'] : 'not set';" 2>&1 | head -1)
+echo "Solr version: $SOLR_VER"
+if [ "$SOLR_VER" != "9" ]; then
+  echo "::error::Expected Solr version 9, got: $SOLR_VER"
+  exit 1
+fi
+
+step "Enabling base modules (search, update, tag1_d7es, pantheon_apachesolr)"
 terminus drush "$SITE_ENV" -- en search update tag1_d7es pantheon_apachesolr -y
 
-# Switch to SFTP mode to download modules via drush dl (closer to user journey)
-echo "Switching to SFTP mode..."
+step "Switching to SFTP mode"
 terminus connection:set "$SITE_ENV" sftp
 
-# Download and install target search module via Tag1 D7ES update server
-echo "Downloading $MODULE via drush dl (Tag1 D7ES)..."
+step "Downloading $MODULE via drush dl (Tag1 D7ES)"
 
 if [ "$MODULE" = "apachesolr" ]; then
   terminus drush "$SITE_ENV" -- dl apachesolr-7.x-1.15 -y
-  echo "Enabling apachesolr and apachesolr_search..."
+
+  step "Enabling apachesolr and apachesolr_search"
   terminus drush "$SITE_ENV" -- en apachesolr apachesolr_search -y
 
 elif [ "$MODULE" = "search_api_solr" ]; then
   terminus drush "$SITE_ENV" -- dl entity search_api -y
   terminus drush "$SITE_ENV" -- dl search_api_solr-7.x-1.19 -y
-  echo "Enabling entity, search_api, search_api_solr..."
+
+  step "Enabling entity, search_api, search_api_solr"
   terminus drush "$SITE_ENV" -- en entity search_api search_api_solr -y
 
 else
@@ -93,12 +96,11 @@ else
   exit 1
 fi
 
-# Commit SFTP changes and switch back to git mode
-echo "Committing SFTP changes..."
+step "Committing SFTP changes and switching to git mode"
 terminus env:commit "$SITE_ENV" --message="CI: Install $MODULE module" --force
 terminus connection:set "$SITE_ENV" git
 
-echo "Verifying modules are enabled..."
+step "Verifying modules are enabled"
 terminus drush "$SITE_ENV" -- pm-list --status=enabled --type=module | grep -iE "$MODULE|pantheon_apachesolr"
 
-echo "=== Phase 1 complete: Multidev $MULTIDEV ready with Solr 9 + $MODULE ==="
+step "Phase 1 complete: Multidev $MULTIDEV ready with Solr 9 + $MODULE"

--- a/.github/scripts/solr9-setup-multidev.sh
+++ b/.github/scripts/solr9-setup-multidev.sh
@@ -34,10 +34,8 @@ rm -rf modules/pantheon/pantheon_apachesolr
 cp -r "$GITHUB_WORKSPACE/modules/pantheon/pantheon_apachesolr" modules/pantheon/pantheon_apachesolr
 
 step "Setting search version to 9 in pantheon.yml"
-if [ -f pantheon.upstream.yml ]; then
-  cp pantheon.upstream.yml pantheon.yml
-fi
-if grep -q "^search:" pantheon.yml 2>/dev/null; then
+touch pantheon.yml
+if grep -q "^search:" pantheon.yml; then
   sed -i "s/^\([[:space:]]*\)version: [0-9]*/\1version: 9/" pantheon.yml
 else
   echo "search:" >> pantheon.yml

--- a/.github/scripts/solr9-shared.sh
+++ b/.github/scripts/solr9-shared.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# Shared helpers for solr9 CUJ scripts. Sourced, not executed.
+# No set flags here: they would leak into the sourcing script's shell.
+
+step() { echo ""; echo ">>>>>>>>>> $1 <<<<<<<<<<"; echo ""; }
+
+drush_ev() {
+  terminus drush "$SITE_ENV" -- ev "$@" 2>&1
+}

--- a/.github/workflows/solr9-cujs.yml
+++ b/.github/workflows/solr9-cujs.yml
@@ -83,6 +83,9 @@ jobs:
       - name: CUJ 6 - Configure Solr Server
         run: bash .github/scripts/solr9-cuj6-configure-server.sh
 
+      - name: CUJ 7 - Create and Configure Search Index
+        run: bash .github/scripts/solr9-cuj7-create-index.sh
+
       # TODO: Re-enable after testing is complete
       # - name: Delete multidev on success
       #   if: success()

--- a/.github/workflows/solr9-cujs.yml
+++ b/.github/workflows/solr9-cujs.yml
@@ -30,18 +30,18 @@ jobs:
       MODULE: ${{ matrix.module }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@8358ee0e2e8afe63c2fb8253d1d52085811ab1e5 # v2
         with:
           php-version: '8.2'
           tools: composer:v2
 
       - name: Install Terminus
-        uses: pantheon-systems/terminus-github-actions@v1
+        uses: pantheon-systems/terminus-github-actions@409451ede17f75acac08f42edc823fee6c435057 # v1.2.8
         with:
           pantheon-machine-token: ${{ env.TERMINUS_TOKEN }}
 
@@ -49,7 +49,7 @@ jobs:
         run: terminus auth:whoami
 
       - name: Setup SSH
-        uses: webfactory/ssh-agent@v0.9.1
+        uses: webfactory/ssh-agent@a6f90b1f127823b31d4d4a8d96047790581349bd # v0.9.1
         with:
           ssh-private-key: ${{ env.PANTHEON_SSH_KEY }}
 
@@ -79,6 +79,9 @@ jobs:
 
       - name: Create multidev and configure Solr 9
         run: bash .github/scripts/solr9-setup-multidev.sh "$MULTIDEV" "$TERMINUS_SITE"
+
+      - name: CUJ 6 - Configure Solr Server
+        run: bash .github/scripts/solr9-cuj6-configure-server.sh
 
       # TODO: Re-enable after testing is complete
       # - name: Delete multidev on success

--- a/.github/workflows/solr9-cujs.yml
+++ b/.github/workflows/solr9-cujs.yml
@@ -26,7 +26,7 @@ jobs:
     env:
       TERMINUS_SITE: ${{ vars.PANTHEON_SITE_D7 }}
       TERMINUS_TOKEN: ${{ secrets.TERMINUS_TOKEN }}
-      PANTHEON_SSH_KEY: ${{ secrets.PANTHEON_SSH_KEY }}
+      PANTHEON_SSH_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
       MODULE: ${{ matrix.module }}
     steps:
       - name: Checkout

--- a/.github/workflows/solr9-cujs.yml
+++ b/.github/workflows/solr9-cujs.yml
@@ -86,6 +86,9 @@ jobs:
       - name: CUJ 7 - Create and Configure Search Index
         run: bash .github/scripts/solr9-cuj7-create-index.sh
 
+      - name: CUJ 8 - Validate Search Results
+        run: bash .github/scripts/solr9-cuj8-validate-search.sh
+
       # TODO: Re-enable after testing is complete
       # - name: Delete multidev on success
       #   if: success()

--- a/.github/workflows/solr9-cujs.yml
+++ b/.github/workflows/solr9-cujs.yml
@@ -71,10 +71,10 @@ jobs:
           else
             MODULE_SHORT="sapi"
           fi
-          MULTIDEV_NAME="d7s9${MODULE_SHORT}${GITHUB_RUN_NUMBER}"
+          MULTIDEV_NAME="s9${MODULE_SHORT}${GITHUB_RUN_NUMBER}"
           MULTIDEV="${MULTIDEV_NAME:0:11}"
           echo "MULTIDEV=$MULTIDEV" >> "$GITHUB_ENV"
-          echo "MULTIDEV_PREFIX=d7s9${MODULE_SHORT}" >> "$GITHUB_ENV"
+          echo "MULTIDEV_PREFIX=s9${MODULE_SHORT}" >> "$GITHUB_ENV"
           echo "Using multidev: $MULTIDEV"
 
       - name: Create multidev and configure Solr 9

--- a/.github/workflows/solr9-cujs.yml
+++ b/.github/workflows/solr9-cujs.yml
@@ -89,10 +89,9 @@ jobs:
       - name: CUJ 8 - Validate Search Results
         run: bash .github/scripts/solr9-cuj8-validate-search.sh
 
-      # TODO: Re-enable after testing is complete
-      # - name: Delete multidev on success
-      #   if: success()
-      #   run: terminus multidev:delete "$TERMINUS_SITE.$MULTIDEV" --delete-branch --yes || true
+      - name: Delete multidev on success
+        if: success()
+        run: terminus multidev:delete "$TERMINUS_SITE.$MULTIDEV" --delete-branch --yes || true
 
       - name: Show multidev URL on failure
         if: failure()

--- a/.github/workflows/solr9-cujs.yml
+++ b/.github/workflows/solr9-cujs.yml
@@ -82,7 +82,7 @@ jobs:
 
       - name: Show multidev URL on failure
         if: failure()
-        run: echo "Multidev URL for investigation: https://${MULTIDEV}-${TERMINUS_SITE}.pantheonsite.io"
+        run: 'echo "Multidev URL for investigation: https://${MULTIDEV}-${TERMINUS_SITE}.pantheonsite.io"'
 
       - name: Cleanup stale CI multidevs
         if: always()

--- a/.github/workflows/solr9-cujs.yml
+++ b/.github/workflows/solr9-cujs.yml
@@ -1,0 +1,96 @@
+name: Solr 9 CUJ Tests
+
+on:
+  push:
+    paths:
+      - 'modules/pantheon/pantheon_apachesolr/**'
+      - '.github/workflows/solr9-cujs.yml'
+      - '.github/scripts/solr9-*'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: 'solr9-cujs-${{ github.head_ref || github.ref }}'
+  cancel-in-progress: true
+
+jobs:
+  solr9-cujs:
+    name: Solr 9 CUJs (${{ matrix.module }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        module: [apachesolr, search_api_solr]
+    env:
+      TERMINUS_SITE: ${{ vars.PANTHEON_SITE_D7 }}
+      TERMINUS_TOKEN: ${{ secrets.TERMINUS_TOKEN }}
+      PANTHEON_SSH_KEY: ${{ secrets.PANTHEON_SSH_KEY }}
+      MODULE: ${{ matrix.module }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+          tools: composer:v2
+
+      - name: Install Terminus
+        uses: pantheon-systems/terminus-github-actions@v1
+        with:
+          pantheon-machine-token: ${{ env.TERMINUS_TOKEN }}
+
+      - name: Verify Terminus auth
+        run: terminus auth:whoami
+
+      - name: Setup SSH
+        uses: webfactory/ssh-agent@v0.9.1
+        with:
+          ssh-private-key: ${{ env.PANTHEON_SSH_KEY }}
+
+      - name: Configure SSH
+        run: |
+          mkdir -p ~/.ssh
+          printf "Host *\n  StrictHostKeyChecking no\n  UserKnownHostsFile=/dev/null\n" > ~/.ssh/config
+
+      - name: Setup Git
+        run: |
+          git config --global user.email "ci@pantheon.io"
+          git config --global user.name "Github Actions"
+          git config --global --add safe.directory '*'
+
+      - name: Set multidev name
+        run: |
+          MODULE_SHORT=$(echo "$MODULE" | tr -d '_' | head -c 3)
+          MULTIDEV="s9${MODULE_SHORT}$(printf '%04d' $(( GITHUB_RUN_NUMBER % 10000 )) )"
+          MULTIDEV="${MULTIDEV:0:11}"
+          echo "MULTIDEV=$MULTIDEV" >> "$GITHUB_ENV"
+          echo "MULTIDEV_PREFIX=s9${MODULE_SHORT}" >> "$GITHUB_ENV"
+          echo "Using multidev: $MULTIDEV"
+
+      - name: Create multidev and configure Solr 9
+        run: bash .github/scripts/solr9-setup-multidev.sh "$MULTIDEV" "$TERMINUS_SITE"
+
+      - name: Delete multidev on success
+        if: success()
+        run: terminus multidev:delete "$TERMINUS_SITE.$MULTIDEV" --delete-branch --yes || true
+
+      - name: Show multidev URL on failure
+        if: failure()
+        run: echo "Multidev URL for investigation: https://${MULTIDEV}-${TERMINUS_SITE}.pantheonsite.io"
+
+      - name: Cleanup stale CI multidevs
+        if: always()
+        run: |
+          MULTIDEVS=$(terminus multidev:list "$TERMINUS_SITE" --format=list 2>/dev/null || echo "")
+          for env in $MULTIDEVS; do
+            if [[ "$env" == ${MULTIDEV_PREFIX}* && "$env" != "$MULTIDEV" ]]; then
+              echo "Deleting stale multidev: $env"
+              terminus multidev:delete "$TERMINUS_SITE.$env" --delete-branch --yes || true
+            fi
+          done

--- a/.github/workflows/solr9-cujs.yml
+++ b/.github/workflows/solr9-cujs.yml
@@ -66,19 +66,24 @@ jobs:
 
       - name: Set multidev name
         run: |
-          MODULE_SHORT=$(echo "$MODULE" | tr -d '_' | head -c 3)
-          MULTIDEV="s9${MODULE_SHORT}$(printf '%04d' $(( GITHUB_RUN_NUMBER % 10000 )) )"
-          MULTIDEV="${MULTIDEV:0:11}"
+          if [ "$MODULE" = "apachesolr" ]; then
+            MODULE_SHORT="apch"
+          else
+            MODULE_SHORT="sapi"
+          fi
+          MULTIDEV_NAME="d7s9${MODULE_SHORT}${GITHUB_RUN_NUMBER}"
+          MULTIDEV="${MULTIDEV_NAME:0:11}"
           echo "MULTIDEV=$MULTIDEV" >> "$GITHUB_ENV"
-          echo "MULTIDEV_PREFIX=s9${MODULE_SHORT}" >> "$GITHUB_ENV"
+          echo "MULTIDEV_PREFIX=d7s9${MODULE_SHORT}" >> "$GITHUB_ENV"
           echo "Using multidev: $MULTIDEV"
 
       - name: Create multidev and configure Solr 9
         run: bash .github/scripts/solr9-setup-multidev.sh "$MULTIDEV" "$TERMINUS_SITE"
 
-      - name: Delete multidev on success
-        if: success()
-        run: terminus multidev:delete "$TERMINUS_SITE.$MULTIDEV" --delete-branch --yes || true
+      # TODO: Re-enable after testing is complete
+      # - name: Delete multidev on success
+      #   if: success()
+      #   run: terminus multidev:delete "$TERMINUS_SITE.$MULTIDEV" --delete-branch --yes || true
 
       - name: Show multidev URL on failure
         if: failure()


### PR DESCRIPTION
## Summary

- Add GHA workflow for Solr 9 CUJ testing (CUJs 6, 7, 8)
- Matrix tests both Apache Solr Search and Search API Solr modules
- Creates multidev from fixture site, installs modules via SFTP + Tag1 D7ES
- Solr 9 set once on the dev fixture (`pantheon.yml`); all multidevs inherit it
- Path-filtered trigger on `modules/pantheon/pantheon_apachesolr/**` changes + `workflow_dispatch`
- Bootstrap script to recreate the fixture site from scratch (hardened + verified end-to-end)
- Commit-pinned GitHub Actions

## Context

[SITE-5766](https://getpantheon.atlassian.net/browse/SITE-5766)

Part of D7 Solr 9 beta (SITE-1745 epic). Tests CUJs 6, 7, 8 for both Apache Solr Search and Search API Solr modules against Solr 9 on D7 multidev environments.

## Review feedback addressed

- Multidev name prefix shortened `d7s9<module>` → `s9<module>` to avoid run-number collisions (11-char cap; headroom raised from ~1000 to ~100000 runs)
- Org name removed from version control; bootstrap `-o <org>` now required
- Admin password generated at install instead of hardcoded
- Shared `step()`/`drush_ev()` helpers extracted to `solr9-shared.sh`
- Solr 9 set once on dev fixture; per-multidev `pantheon.yml` edit removed (multidevs inherit), saving a deploy cycle per CI run

## Bootstrap script hardening

The bootstrap script (`solr9-bootstrap-fixture.sh`) was failing end-to-end and has been fixed:

- **Connection modes (blocker):** `connection:set git` before the `pantheon.yml` push and `connection:set sftp` before `site-install`. Fresh sites default to SFTP (rejects git pushes); git mode mounts code read-only and breaks `site-install`. Without these toggles the script aborted at step 3.
- **Portable `sed`:** `sed -i.bak` works on both GNU/Linux CI and BSD/macOS (bare `sed -i` errors on macOS).
- **Verification trust:** step 6 now asserts the `(OK)` marker in captured output instead of relying on the drush PHP `exit(1)` propagating back through terminus.
- **No swallowed commit failures:** a real `git commit` failure (gpg signing, pre-commit hook) now aborts instead of being masked by `|| echo`, which previously let `git push` land nothing and produce a fixture missing `search: version: 9`.
- **Correct step counters:** `[1/6]`…`[6/6]` (were mislabeled `[1/5]`/`[2/5]`).
- **`-h` exit code:** help exits 0; argument errors exit 1.

## Files

| File | Purpose |
|------|---------|
| `.github/workflows/solr9-cujs.yml` | GHA workflow with matrix (apachesolr, search_api_solr) |
| `.github/scripts/solr9-setup-multidev.sh` | Creates multidev, installs modules via SFTP + Tag1 D7ES |
| `.github/scripts/solr9-shared.sh` | Shared helpers (`step`, `drush_ev`) sourced by CUJ scripts |
| `.github/scripts/solr9-cuj6-configure-server.sh` | Post schema, verify ping, configure server |
| `.github/scripts/solr9-cuj7-create-index.sh` | Configure indexing, index content, verify |
| `.github/scripts/solr9-cuj8-validate-search.sh` | Search validation, watchdog check, ping |
| `.github/scripts/solr9-bootstrap-fixture.sh` | Recreate fixture site from scratch |

## CUJ Details

**CUJ 6: Configure Solr Server**
- Apache Solr Search: auto-configures via env vars, no "Add server" step
- Search API Solr: creates server programmatically with full connection options

**CUJ 7: Create and Configure Search Index**
- Apache Solr Search: configures bundles, `solr-mark-all` + `solr-index`, verifies via `node_search_execute`
- Search API Solr: creates index programmatically (title, body, type, status fields), indexes via `search-api-index`

**CUJ 8: Validate Search Results**
- Both: search known term, search non-existent term, check watchdog, verify ping
- Apache Solr Search: uses `node_search_execute()` (direct Solr API returns 404 from drush context)
- Search API Solr: uses `SearchApiQuery`

## Known Issues

- `PantheonApacheSolrService->commit()` sends unsupported `optimize` param to Solr 9 (400 error, non-blocking). Fixed in PR #223 (37cb8af)
- Direct Solr API queries (Luke, search) return 404 from drush CLI context for apachesolr module (web requests work)
- `search_api_solr` throws `Undefined array key "path"` and `search_api_language` warnings during indexing (PHP 8.1+ deprecations, non-fatal)
- Watchdog type differs: `Apache Solr` for apachesolr module, `search_api_solr` for search_api_solr module
- search_api_solr CUJ 8 intermittently returns 0 results on first run (passes on re-run)

## Fixture Site

- Name: `search-api-pantheon-d7` (Performance Small plan)
- Solr 9 set in dev `pantheon.yml`; multidevs inherit it on creation
- 20 article nodes with real content pre-loaded on dev
- Multidevs inherit content via database clone
- Modules installed per-multidev via SFTP + `drush dl` from Tag1 D7ES

## Test plan

- [x] GHA workflow triggers on path changes and workflow_dispatch
- [x] Both matrix jobs create multidevs successfully
- [x] CUJ 6: Schema posted, ping verified, server configured
- [x] CUJ 7: Content indexed, count verified
- [x] CUJ 8: Search returns results, zero results for non-existent term, watchdog clean, ping healthy
- [x] Multidev cleanup on success
- [x] Bootstrap script creates fixture site from scratch — verified end-to-end against a throwaway site (`search-api-pantheon-d7-test-5`): completes unaided and the dev base matches the existing fixture (Performance Small, Drupal 7.105, PHP 8.2, 20 article nodes, `pantheon.yml` `search: version: 9`); throwaway site deleted after

[SITE-5766]: https://getpantheon.atlassian.net/browse/SITE-5766?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
