### PR TITLE
ci: [SITE-5766] retry transient drush failures in solr9 CUJ scripts

### DIFF
--- a/.github/scripts/solr9-cuj7-create-index.sh
+++ b/.github/scripts/solr9-cuj7-create-index.sh
@@ -22,10 +22,10 @@ if [ "$MODULE" = "apachesolr" ]; then
     apachesolr_index_set_bundles(\$env_id, 'node', array('article', 'page'));
   " || true
   echo "Configured article and page bundles for indexing."
-  terminus drush "$SITE_ENV" -- solr-mark-all
+  retry terminus drush "$SITE_ENV" -- solr-mark-all
 
   step "Step 2: Index content"
-  terminus drush "$SITE_ENV" -- solr-index
+  retry terminus drush "$SITE_ENV" -- solr-index
 
   step "Step 3: Verify index via search"
   VERIFY=$(drush_ev "
@@ -73,10 +73,10 @@ elif [ "$MODULE" = "search_api_solr" ]; then
   fi
 
   step "Step 2: Index content"
-  terminus drush "$SITE_ENV" -- search-api-index site_content
+  retry terminus drush "$SITE_ENV" -- search-api-index site_content
 
   step "Step 3: Verify index status"
-  STATUS=$(terminus drush "$SITE_ENV" -- search-api-status site_content 2>&1)
+  STATUS=$(retry terminus drush "$SITE_ENV" -- search-api-status site_content)
   echo "$STATUS"
 
   if echo "$STATUS" | grep -q "100%"; then

--- a/.github/scripts/solr9-shared.sh
+++ b/.github/scripts/solr9-shared.sh
@@ -4,6 +4,27 @@
 
 step() { echo ""; echo ">>>>>>>>>> $1 <<<<<<<<<<"; echo ""; }
 
+# Run "$@" up to RETRY_MAX times with exponential backoff (RETRY_DELAY base),
+# returning on first success. The command's stdout+stderr go to this function's
+# stdout so $(...) callers still capture output; retry diagnostics go to stderr.
+retry() {
+  local max="${RETRY_MAX:-3}" delay="${RETRY_DELAY:-5}" attempt=1 rc=0
+  while true; do
+    if "$@" 2>&1; then
+      return 0
+    fi
+    rc=$?
+    if [ "$attempt" -ge "$max" ]; then
+      echo "retry: '$*' failed after $attempt attempts (last exit $rc)" >&2
+      return "$rc"
+    fi
+    echo "retry: '$*' exit $rc (attempt $attempt/$max), retrying in ${delay}s" >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+    delay=$((delay * 2))
+  done
+}
+
 drush_ev() {
-  terminus drush "$SITE_ENV" -- ev "$@" 2>&1
+  retry terminus drush "$SITE_ENV" -- ev "$@"
 }


### PR DESCRIPTION
## Summary

- Add a `retry()` helper to `solr9-shared.sh` (configurable attempts/backoff via `RETRY_MAX`/`RETRY_DELAY`).
- Route `drush_ev()` through it, covering every ev-based verify step across the CUJ scripts.
- Wrap the four gating remote drush calls in CUJ 7: `solr-mark-all`, `solr-index`, `search-api-index`, `search-api-status`.

## Context

CUJ 7 (search_api_solr) failed on "Step 3: Verify index status" with exit code 137. That is SIGKILL (128+9): the remote `terminus drush search-api-status` process was OOM-killed or dropped by an SSH timeout on the fixture appserver, not a code bug. The script runs `set -euo pipefail` and that call had no tolerance, so a transient platform blip hard-failed the whole step. Re-running passed, confirming it is transient.

`retry()` absorbs the blip with exponential backoff while still failing the step if the command genuinely fails after all attempts. The wrapped command's stdout+stderr still flow to the caller (so `$(...)` captures are unchanged); retry diagnostics go to stderr so the CI log shows when a retry happened.

Scope kept to the observed failure class. `bootstrap` (its `site-install` already has a poll loop) and `setup-multidev` are left unchanged.

## Test plan

- [ ] solr9-cujs workflow green for both matrix modules (apachesolr, search_api_solr)
- [ ] Confirm retry diagnostics appear in the log only on a transient blip, not on clean runs

## References

- Jira: [SITE-5766](https://getpantheon.atlassian.net/browse/SITE-5766)
- Related PR: pantheon-systems/drops-7#223


[SITE-5766]: https://getpantheon.atlassian.net/browse/SITE-5766?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ