### PR TITLE
ci: [SITE-5766] retry transient drush failures in solr9 CUJ scripts

### DIFF
--- a/.github/scripts/solr9-cuj7-create-index.sh
+++ b/.github/scripts/solr9-cuj7-create-index.sh
@@ -22,10 +22,10 @@ if [ "$MODULE" = "apachesolr" ]; then
     apachesolr_index_set_bundles(\$env_id, 'node', array('article', 'page'));
   " || true
   echo "Configured article and page bundles for indexing."
-  terminus drush "$SITE_ENV" -- solr-mark-all
+  retry terminus drush "$SITE_ENV" -- solr-mark-all
 
   step "Step 2: Index content"
-  terminus drush "$SITE_ENV" -- solr-index
+  retry terminus drush "$SITE_ENV" -- solr-index
 
   step "Step 3: Verify index via search"
   VERIFY=$(drush_ev "
@@ -73,10 +73,10 @@ elif [ "$MODULE" = "search_api_solr" ]; then
   fi
 
   step "Step 2: Index content"
-  terminus drush "$SITE_ENV" -- search-api-index site_content
+  retry terminus drush "$SITE_ENV" -- search-api-index site_content
 
   step "Step 3: Verify index status"
-  STATUS=$(terminus drush "$SITE_ENV" -- search-api-status site_content 2>&1)
+  STATUS=$(retry terminus drush "$SITE_ENV" -- search-api-status site_content)
   echo "$STATUS"
 
   if echo "$STATUS" | grep -q "100%"; then

--- a/.github/scripts/solr9-shared.sh
+++ b/.github/scripts/solr9-shared.sh
@@ -4,6 +4,27 @@
 
 step() { echo ""; echo ">>>>>>>>>> $1 <<<<<<<<<<"; echo ""; }
 
+# Run "$@" up to RETRY_MAX times with exponential backoff (RETRY_DELAY base),
+# returning on first success. The command's stdout+stderr go to this function's
+# stdout so $(...) callers still capture output; retry diagnostics go to stderr.
+retry() {
+  local max="${RETRY_MAX:-3}" delay="${RETRY_DELAY:-5}" attempt=1 rc=0
+  while true; do
+    if "$@" 2>&1; then
+      return 0
+    fi
+    rc=$?
+    if [ "$attempt" -ge "$max" ]; then
+      echo "retry: '$*' failed after $attempt attempts (last exit $rc)" >&2
+      return "$rc"
+    fi
+    echo "retry: '$*' exit $rc (attempt $attempt/$max), retrying in ${delay}s" >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+    delay=$((delay * 2))
+  done
+}
+
 drush_ev() {
-  terminus drush "$SITE_ENV" -- ev "$@" 2>&1
+  retry terminus drush "$SITE_ENV" -- ev "$@"
 }


### PR DESCRIPTION
Add a retry() helper to solr9-shared.sh and route the gating remote drush calls through it (drush_ev plus CUJ 7 solr-mark-all, solr-index, search-api-index, search-api-status). Remote drush over SSH can be killed mid-run (exit 137: OOM or SSH timeout), which previously hard-failed the step under set -e. Retries with exponential backoff absorb the transient blip without masking a genuine failure.